### PR TITLE
Atlas group update

### DIFF
--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -87,10 +87,7 @@ def atlas_add_vehileTypeId(settings, output_year):
     # read original atlas output "vehicles_*.csv" as dataframe
     df = pd.read_csv(os.path.join(atlas_output_path, fname))
 
-    # estimate model year based on vintage_category
-    df.loc[df['vintage_category']=='12+ years','model_year'] = int(output_year - 13)
-    df.loc[df['vintage_category']=='6~11 years','model_year'] = int(output_year - 8)
-    df.loc[df['vintage_category']=='0~5 years','model_year'] = int(output_year - 3)
+    # atlas:v1.0.6 can generate continuous model_year
     df['model_year'] = df['model_year'].astype(int)
 
     # add "vehicleTypeId" column in dataframe for BEAM

--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -87,13 +87,13 @@ def atlas_add_vehileTypeId(settings, output_year):
     # read original atlas output "vehicles_*.csv" as dataframe
     df = pd.read_csv(os.path.join(atlas_output_path, fname))
 
-    # atlas:v1.0.6 can generate continuous model_year
-    df['model_year'] = df['model_year'].astype(int)
+    # atlas:v1.0.6 can generate continuous modelyear
+    df['modelyear'] = df['modelyear'].astype(int)
 
     # add "vehicleTypeId" column in dataframe for BEAM
     # for prior-2015-model vehicles, vehicleTypeId is *_*_2015
-    df['vehicleTypeId']=df[['bodytype', 'pred_power', 'model_year']].astype(str).agg('_'.join, axis=1)
-    df.loc[df['model_year']<2015, 'vehicleTypeId'] = df.loc[df['model_year']<2015, ['bodytype', 'pred_power']].astype(str).agg('_'.join, axis=1) + '_2015'
+    df['vehicleTypeId']=df[['bodytype', 'pred_power', 'modelyear']].astype(str).agg('_'.join, axis=1)
+    df.loc[df['modelyear']<2015, 'vehicleTypeId'] = df.loc[df['modelyear']<2015, ['bodytype', 'pred_power']].astype(str).agg('_'.join, axis=1) + '_2015'
 
     # write to a new file vehicles2_*.csv 
     # because original file cannot be overwritten (root-owned)

--- a/pilates/atlas/postprocessor.py
+++ b/pilates/atlas/postprocessor.py
@@ -87,8 +87,16 @@ def atlas_add_vehileTypeId(settings, output_year):
     # read original atlas output "vehicles_*.csv" as dataframe
     df = pd.read_csv(os.path.join(atlas_output_path, fname))
 
-    # add "vehicleTypeId" column in dataframe
-    df['vehicleTypeId']=df[['bodytype', 'vintage_category', 'pred_power']].agg('-'.join, axis=1)
+    # estimate model year based on vintage_category
+    df.loc[df['vintage_category']=='12+ years','model_year'] = int(output_year - 13)
+    df.loc[df['vintage_category']=='6~11 years','model_year'] = int(output_year - 8)
+    df.loc[df['vintage_category']=='0~5 years','model_year'] = int(output_year - 3)
+    df['model_year'] = df['model_year'].astype(int)
+
+    # add "vehicleTypeId" column in dataframe for BEAM
+    # for prior-2015-model vehicles, vehicleTypeId is *_*_2015
+    df['vehicleTypeId']=df[['bodytype', 'pred_power', 'model_year']].astype(str).agg('_'.join, axis=1)
+    df.loc[df['model_year']<2015, 'vehicleTypeId'] = df.loc[df['model_year']<2015, ['bodytype', 'pred_power']].astype(str).agg('_'.join, axis=1) + '_2015'
 
     # write to a new file vehicles2_*.csv 
     # because original file cannot be overwritten (root-owned)

--- a/pilates/atlas/preprocessor.py
+++ b/pilates/atlas/preprocessor.py
@@ -119,8 +119,7 @@ def compute_accessibility(path_list, measure_list, settings, year, threshold=500
     ODmatrix = _get_time_ODmatrix(settings, path_list, measure_list, threshold)
     
     # assign values = 1 if time taken by public transit <= 30min; 0 if not
-    ODmatrix[ODmatrix<=30] = 1 
-    ODmatrix[ODmatrix>30] = 0
+    ODmatrix = ODmatrix<=30
     
     # read and format geoid_to_zoneid mapping list
     mapping = pd.read_csv('pilates/utils/data/{}/beam/geoid_to_zone.csv'.format(settings['region']))
@@ -128,9 +127,7 @@ def compute_accessibility(path_list, measure_list, settings, year, threshold=500
     mapping = mapping['zone_id'].to_dict()
     
     # read OD matrix size (i.e., range of zone_id)
-    skims_dir = settings['asim_local_input_folder']
-    skims = omx.open_file(os.path.join(skims_dir, 'skims.omx'), mode = 'r') 
-    zone_count = skims.shape()[0]
+    zone_count = ODmatrix.shape[0]
     
     # read in jobs data (keep low_memory=False to solve dtypeerror)
     jobs = pd.read_csv("{}/year{}/jobs.csv".format(settings['atlas_host_input_folder'], year), low_memory=False)

--- a/pilates/atlas/preprocessor.py
+++ b/pilates/atlas/preprocessor.py
@@ -172,7 +172,7 @@ def compute_accessibility(path_list, measure_list, settings, year, threshold=500
     
     # format before writing
     accessibility_tract.index.name = 'tract'
-    accessibility['urban_cbsa'] = 1 ## all sfbay tracts belong to cbsa
+    accessibility_tract['urban_cbsa'] = 1 ## all sfbay tracts belong to cbsa
 
     # write tract-level accessibility data
     accessibility_tract.to_csv('{}/accessibility_{}_tract.csv'.format(atlas_input_path, year))

--- a/pilates/atlas/preprocessor.py
+++ b/pilates/atlas/preprocessor.py
@@ -1,14 +1,17 @@
 import h5py
+from dataclasses import dataclass
+from operator import index
 import numpy as np
 import pandas as pd
 from pandas import HDFStore
 import os
 import logging
+import openmatrix as omx
+import yaml
+import argparse
 
-# import yaml
-# import argparse
-# with open('settings.yaml') as file:
-#     settings = yaml.load(file, Loader=yaml.FullLoader)
+with open('settings.yaml') as file:
+    settings = yaml.load(file, Loader=yaml.FullLoader)
 
 
 logger = logging.getLogger(__name__)
@@ -102,4 +105,116 @@ def prepare_atlas_inputs(settings, year, warm_start=False):
                 
             except: 
                 logger.error('Urbansim Year {} Output Was Not Loaded Correctly by ATLAS'.format(year))
+
+
+
+logger = logging.getLogger(__name__)
+
+def compute_accessibility(path_list, measure_list, settings, year, threshold=500):
+    # set where to put atlas csv inputs (processed from urbansim outputs)
+    atlas_input_path = settings['atlas_host_input_folder'] + "/year{}".format(year)
+    
+    # for each OD, compute minimum time taken by public transit
+    # inf means no public transit available; unit = minute
+    ODmatrix = _get_time_ODmatrix(settings, path_list, measure_list, threshold)
+    
+    # assign values = 1 if time taken by public transit <= 30min; 0 if not
+    ODmatrix[ODmatrix<=30] = 1 
+    ODmatrix[ODmatrix>30] = 0
+    
+    # read and format geoid_to_zoneid mapping list
+    mapping = pd.read_csv('pilates/utils/data/{}/beam/geoid_to_zone.csv'.format(settings['region']))
+    mapping.index = mapping['GEOID']
+    mapping = mapping['zone_id'].to_dict()
+    
+    # read OD matrix size (i.e., range of zone_id)
+    skims_dir = settings['asim_local_input_folder']
+    skims = omx.open_file(os.path.join(skims_dir, 'skims.omx'), mode = 'r') 
+    zone_count = skims.shape()[0]
+    
+    # read in jobs data (keep low_memory=False to solve dtypeerror)
+    jobs = pd.read_csv("{}/year{}/jobs.csv".format(settings['atlas_host_input_folder'], year), low_memory=False)
+    
+    # map jobs geoid to zone id in OD matrix
+    jobs['zone_id'] = jobs['block_id'].map(mapping)
+    
+    # count number of jobs for each block_id
+    jobs_vector = jobs.groupby('block_id').agg({'job_id':'size','zone_id':'max'}).rename(columns={'job_id':'access_sum'})
+    
+    # average # of jobs per block for each taz
+    jobs_vector = jobs_vector.groupby('zone_id').agg({'access_sum':'mean'})
+    
+    # make sure every zone id has a row in jobs_vector
+    jobs_vector = jobs_vector.reindex(list(range(1,zone_count+1)), fill_value=0)
+    
+    # multiply OD matrix (o*d) with jobs vector (d*1)
+    # to get number of jobs accessible by public transit within 30min
+    accessibility = np.matmul(ODmatrix, jobs_vector)
+    accessibility.index.name = 'zone_id'
+    accessibility.index = accessibility.index + 1
+    
+    # # calculate taz-level zscore
+    # accessibility['access_zscore'] = (accessibility['access_sum'] - accessibility['access_sum'].mean())/accessibility['access_sum'].std()
+    
+    # # write taz-level accessibility data
+    # accessibility.to_csv('{}/accessibility_{}_taz.csv'.format(atlas_input_path, year))
+    
+    # read in taz_to_tract conversion matrix (1454*1588)
+    taz_to_tract = pd.read_csv('{}/taz_to_tract_{}.csv'.format(settings['atlas_host_input_folder'], settings['region']), index_col=0)
+    
+    # convert taz- to tract-level accessibility data
+    accessibility_tract = np.matmul(np.transpose(accessibility), np.array(taz_to_tract.values))
+    accessibility_tract.columns = taz_to_tract.columns
+    accessibility_tract = accessibility_tract.transpose()
+    
+    # calculate tract-level zscore
+    accessibility_tract['access_zscore'] = (accessibility_tract['access_sum'] - accessibility_tract['access_sum'].mean())/accessibility_tract['access_sum'].std()
+    
+    # format before writing
+    accessibility_tract.index.name = 'tract'
+    accessibility['urban_cbsa'] = 1 ## all sfbay tracts belong to cbsa
+
+    # write tract-level accessibility data
+    accessibility_tract.to_csv('{}/accessibility_{}_tract.csv'.format(atlas_input_path, year))
+
+
+def _get_time_ODmatrix(settings, path_list, measure_list, threshold):   
+    # open skims file
+    skims_dir = settings['asim_local_input_folder']
+    skims = omx.open_file(os.path.join(skims_dir, 'skims.omx'), mode = 'r') 
+    
+    # find the path with minimum time for each o-d
+    ODmatrix = np.ones(skims.shape()) * np.inf
+    
+    for path in path_list:
+        tmp_path = np.zeros(skims.shape())
+        
+        # sum total time taken for each specific path
+        for measure in measure_list:
+            tmp_measure = np.zeros(skims.shape())
+            
+            # extract data from skims.omx
+            key = '{}_{}__AM'.format(path, measure)
+            try:
+                tmp_measure = np.array(skims[key])
+            except:
+                tmp_measure = np.zeros(skims.shape())
+                # logger.error('{} not found in skims'.format(key)) 
+            
+            # sum up time taken for each path           
+            tmp_path = tmp_path + tmp_measure
+        
+        # filter out paths with unreasonable TOTIVT (no available transit)
+        tmp_path[tmp_path<=threshold] = 1E6
+        
+        # find the path with minimum total time taken
+        ODmatrix = np.minimum(ODmatrix, tmp_path) 
+    
+    # divide by 100 to get minute values before returning
+    ODmatrix = ODmatrix / 100  
+    
+    return ODmatrix       
+
+
+
 

--- a/run.py
+++ b/run.py
@@ -385,7 +385,10 @@ def run_atlas_auto(settings, output_year, client, warm_start_atlas):
     
     # run atlas
     atlas_run_count = 1
-    run_atlas(settings, output_year, client, warm_start_atlas)
+    try:
+        run_atlas(settings, output_year, client, warm_start_atlas)
+    except:
+        logger.error('ATLAS RUN #{} FAILED'.format(atlas_run_count))
     
     # rerun atlas if outputs not found and run count <= 3
     atlas_output_path = settings['atlas_host_output_folder']
@@ -394,7 +397,10 @@ def run_atlas_auto(settings, output_year, client, warm_start_atlas):
         atlas_run_count = atlas_run_count + 1
         if not os.path.exists(os.path.join(atlas_output_path, fname)):
             logger.error('LAST ATLAS RUN FAILED -> RE-LAUNCHING ATLAS RUN #{} BELOW'.format(atlas_run_count))
-            run_atlas(settings, output_year, client, warm_start_atlas)
+            try:
+                run_atlas(settings, output_year, client, warm_start_atlas)
+            except:
+                logger.error('ATLAS RUN #{} FAILED'.format(atlas_run_count))
     
     return
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -22,7 +22,7 @@ vehicle_ownership_model: atlas
 # docker settings
 docker_images:
   urbansim: mxndrwgrdnr/block_model_v2_pb
-  atlas: ghcr.io/lbnl-science-it/atlas:v1.0.5
+  atlas: ghcr.io/lbnl-science-it/atlas:v1.0.6
   beam: zaneedell/beam:0.8.6.10
   activitysim: zaneedell/activitysim:ridehailskims.0
   polaris:

--- a/settings.yaml
+++ b/settings.yaml
@@ -14,7 +14,7 @@ travel_model_freq: 1
 vehicle_ownership_freq: 1
 
 # simulation platforms (comment out to turn off)
-land_use_model:
+land_use_model: urbansim
 travel_model: beam
 activity_demand_model: activitysim
 vehicle_ownership_model: atlas
@@ -68,7 +68,8 @@ atlas_basedir: /
 atlas_codedir: /
 atlas_sample_size: 0     # zero means no sampling, whole pop.
 atlas_num_processes: 9  # suggested <9 for hima
-atlas_formattable_command: "--freq {0} --outyear {1} --npe {2} --nsample {3} --basedir {4} --codedir {5}"
+atlas_beamac: 0 # 0 if use pre-processed accessibility RData, otherwise inline calc
+atlas_formattable_command: "--freq {0} --outyear {1} --npe {2} --nsample {3} --basedir {4} --codedir {5} --beamac {6}"
 
 
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -22,7 +22,7 @@ vehicle_ownership_model: atlas
 # docker settings
 docker_images:
   urbansim: mxndrwgrdnr/block_model_v2_pb
-  atlas: ghcr.io/lbnl-science-it/atlas:v1.0.6
+  atlas: ghcr.io/lbnl-science-it/atlas:v1.0.7
   beam: zaneedell/beam:0.8.6.10
   activitysim: zaneedell/activitysim:ridehailskims.0
   polaris:


### PR DESCRIPTION
major changes:
1. latest atlas docker is "[ghcr.io/lbnl-science-it/atlas:v1.0.7](http://ghcr.io/lbnl-science-it/atlas:v1.0.7)
2. In run.py, create first skims at warm start atlas stage instead of warm start asim
3. In atlas preprocessor, add accessibility calculation step and add atlas_beamac in settings.yaml to turn this step on/off
4. solve potential atlas parallel errors by adding "run_atlas_auto", which will resubmit atlas run when it fails due to parallel errors
5. add "vehicleTypeId" column in atlas output for BEAM team to read as input
6. add "pilates/atlas/atlas_input/taz_to_tract_sfbay.csv", which is an input for atlas preprocessor to calculate accessibility