### PR TITLE
delete MEP outputs

### DIFF
--- a/clean_beam_data.sh
+++ b/clean_beam_data.sh
@@ -21,3 +21,5 @@ sudo rm pilates/urbansim/data/model*
 
 echo "Deleting inexus output data"
 sudo rm pilates/postprocessing/output/*
+sudo rm pilates/postprocessing/MEP/*
+


### PR DESCRIPTION
Automatically delete MEP outputs when using 'clean_beam_outputs'