### PR TITLE
Recovery root alignment

### DIFF
--- a/docs/run/run_promotion.md
+++ b/docs/run/run_promotion.md
@@ -122,6 +122,21 @@ python -m pilates.runtime.promote_run_archive \
   --merge-only
 ```
 
+If you trust the promoted copy and want to skip the byte-level Consist
+verification of recovery-copy files as well, add `--no-recovery-copy-verify`.
+Keep this opt-in path narrow; it avoids re-reading each promoted output file but
+removes the independent checksum check on the NFS copy:
+
+```bash
+python -m pilates.runtime.promote_run_archive \
+  -c scenarios/seattle/settings-seattle-consist-hpc.yaml \
+  --run-dir /global/scratch/users/$USER/pilates-outputs/pilates-run--seattle--my-run--20260505T120000 \
+  --root /clusterfs/<project-or-nfs-root>/$USER/pilates-outputs \
+  --merge-main-db "$MAIN_DB" \
+  --merge-only \
+  --no-recovery-copy-verify
+```
+
 By default the helper uses `--merge-conflict error`. That is intentional: the
 filtered shard should contain only the new root run subtree, so any run-ID
 conflict usually means the wrong root was selected or the run was already

--- a/docs/run/run_promotion.md
+++ b/docs/run/run_promotion.md
@@ -109,6 +109,19 @@ python -m pilates.runtime.promote_run_archive \
   --merge-main-db "$MAIN_DB"
 ```
 
+If the archive copy already exists from the dry-run and you only want to reuse
+it for the real main-DB merge, add `--merge-only` instead of repeating the full
+copy:
+
+```bash
+python -m pilates.runtime.promote_run_archive \
+  -c scenarios/seattle/settings-seattle-consist-hpc.yaml \
+  --run-dir /global/scratch/users/$USER/pilates-outputs/pilates-run--seattle--my-run--20260505T120000 \
+  --root /clusterfs/<project-or-nfs-root>/$USER/pilates-outputs \
+  --merge-main-db "$MAIN_DB" \
+  --merge-only
+```
+
 By default the helper uses `--merge-conflict error`. That is intentional: the
 filtered shard should contain only the new root run subtree, so any run-ID
 conflict usually means the wrong root was selected or the run was already

--- a/pilates/activitysim/postprocessor.py
+++ b/pilates/activitysim/postprocessor.py
@@ -95,16 +95,8 @@ def _next_iter_usim_input_store_path(
     artifact. Writing to ``model_data_<year>.h5`` instead would clobber the
     urbansim run output and destroy its ``/<year>/``-prefixed table layout.
     """
-    forecast_year = resolve_forecast_year(state)
     try:
-        if forecast_year is not None and getattr(
-            getattr(settings, "urbansim", None), "output_file_template", None
-        ):
-            datastore_name = get_usim_datastore_fname(
-                settings, io="output", year=forecast_year
-            )
-        else:
-            datastore_name = get_usim_datastore_fname(settings, io="input")
+        datastore_name = get_usim_datastore_fname(settings, io="input")
     except Exception:
         return None
     return os.path.join(workspace.get_usim_mutable_data_dir(), datastore_name)

--- a/pilates/activitysim/preprocessor.py
+++ b/pilates/activitysim/preprocessor.py
@@ -15,6 +15,7 @@ import geopandas as gpd
 from shapely import wkt
 from tqdm import tqdm
 import matplotlib.pyplot as plt
+import yaml
 
 from pilates.config import PilatesConfig
 from pilates.activitysim.outputs import ActivitySimPreprocessOutputs
@@ -48,6 +49,15 @@ if TYPE_CHECKING:
     from pilates.workspace import Workspace
 
 logger = logging.getLogger(__name__)
+_ASIM_ATLAS_DISABLED_VEHICLE_MODEL_NAMES = frozenset(
+    {
+        "vehicle_ownership",
+        "auto_ownership_simulate",
+        "vehicle_type_choice",
+        "vehicle_type_choice_simulate",
+        "vehicle_allocation",
+    }
+)
 
 # Define expected data types for BEAM raw skims CSV files.
 # This helps in efficient memory usage and correct data interpretation when reading large CSVs.
@@ -371,6 +381,90 @@ def required_asim_config_dirs(main_configs_dir: str) -> list[str]:
         seen.add(dirname)
         result.append(dirname)
     return result
+
+
+def _is_atlas_vehicle_ownership_enabled(settings: PilatesConfig) -> bool:
+    model = get_setting(
+        settings,
+        "run.models.vehicle_ownership",
+        default=get_setting(settings, "vehicle_ownership_model"),
+    )
+    return str(model).lower() == "atlas"
+
+
+def _model_name_for_activitysim_disable(model_entry: Any) -> Optional[str]:
+    if isinstance(model_entry, str):
+        return model_entry
+    if isinstance(model_entry, dict) and len(model_entry) == 1:
+        return str(next(iter(model_entry)))
+    return None
+
+
+def _disable_activitysim_vehicle_ownership_models_in_file(
+    settings_path: Path,
+) -> list[str]:
+    loaded = yaml.safe_load(settings_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(loaded, dict):
+        return []
+    models = loaded.get("models")
+    if not isinstance(models, list):
+        return []
+
+    kept_models = []
+    removed: list[str] = []
+    for model in models:
+        model_name = _model_name_for_activitysim_disable(model)
+        if (
+            model_name is not None
+            and model_name.lower() in _ASIM_ATLAS_DISABLED_VEHICLE_MODEL_NAMES
+        ):
+            removed.append(model_name)
+            continue
+        kept_models.append(model)
+
+    if not removed:
+        return []
+
+    loaded["models"] = kept_models
+    settings_path.write_text(
+        yaml.safe_dump(loaded, sort_keys=False),
+        encoding="utf-8",
+    )
+    return removed
+
+
+def _disable_activitysim_vehicle_ownership_models_for_atlas(
+    *,
+    settings: PilatesConfig,
+    configs_dest_dir: str,
+    main_configs_dir: str,
+) -> Dict[str, list[str]]:
+    """
+    Remove ActivitySim ownership model steps when ATLAS is the ownership source.
+
+    ATLAS owns household vehicle ownership in integrated runs. ActivitySim may
+    still consume vehicle ownership fields, but it must not recompute them and
+    overwrite the post-ATLAS population before BEAM staging.
+    """
+    if not _is_atlas_vehicle_ownership_enabled(settings):
+        return {}
+
+    removed_by_file: Dict[str, list[str]] = {}
+    for dirname in required_asim_config_dirs(main_configs_dir):
+        settings_path = Path(configs_dest_dir) / dirname / "settings.yaml"
+        if not settings_path.exists():
+            continue
+        removed = _disable_activitysim_vehicle_ownership_models_in_file(settings_path)
+        if not removed:
+            continue
+        removed_by_file[str(settings_path)] = removed
+        logger.warning(
+            "Disabled ActivitySim vehicle ownership model steps because ATLAS is "
+            "the configured ownership source. settings=%s removed_models=%s",
+            settings_path,
+            removed,
+        )
+    return removed_by_file
 
 
 ####################################
@@ -2918,6 +3012,13 @@ def _copy_data_to_mutable_location(
     )
     _copytree_if_needed(configs_source_dir, configs_dest_dir)
     _ensure_required_asim_config_dirs(
+        configs_dest_dir=configs_dest_dir,
+        main_configs_dir=get_setting(
+            settings, "activitysim.main_configs_dir", "configs"
+        ),
+    )
+    _disable_activitysim_vehicle_ownership_models_for_atlas(
+        settings=settings,
         configs_dest_dir=configs_dest_dir,
         main_configs_dir=get_setting(
             settings, "activitysim.main_configs_dir", "configs"

--- a/pilates/atlas/outputs.py
+++ b/pilates/atlas/outputs.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Iterable, Optional, Tuple, TYPE_CHECKING
 
+import pandas as pd
+
+from pilates.utils.coupler_helpers import artifact_to_existing_path
+from pilates.utils.usim_h5 import resolve_usim_h5_table_key
 from pilates.workflows.artifact_keys import (
     ATLAS_VEHICLES2_OUTPUT,
     USIM_POPULATION_SOURCE_H5,
@@ -65,6 +69,59 @@ class AtlasPreprocessOutputs(StepOutputsBase):
             raise AssertionError(
                 "AtlasPreprocessOutputs must include atlas_grave_csv when atlas year exceeds the global start_year."
             )
+        _validate_atlas_households_match_selected_h5(self, context)
+
+
+def _validate_atlas_households_match_selected_h5(
+    outputs: AtlasPreprocessOutputs,
+    context: Optional[ValidationContext],
+) -> None:
+    if context is None:
+        return
+    state = context.state
+    workspace = context.workspace
+    if state is None or workspace is None:
+        return
+
+    households_csv = outputs.prepared_inputs.get("atlas_households_csv")
+    selected_h5 = getattr(state, "atlas_usim_datastore_h5", None)
+    if households_csv is None or selected_h5 is None:
+        return
+    h5_path = artifact_to_existing_path(selected_h5, workspace=workspace)
+    if h5_path is None:
+        return
+
+    year = getattr(state, "year", getattr(state, "current_year", None))
+    if year is None:
+        return
+
+    atlas_households = pd.read_csv(households_csv, usecols=["household_id"])
+    with pd.HDFStore(h5_path, mode="r") as store:
+        h5_table_path = resolve_usim_h5_table_key(
+            store,
+            year=int(year),
+            table="households",
+        )
+        h5_households = store[h5_table_path]
+
+    atlas_ids = pd.Index(
+        pd.to_numeric(atlas_households["household_id"], errors="raise").astype("int64")
+    )
+    h5_ids = pd.Index(h5_households.index.astype("int64"))
+    missing_in_h5 = atlas_ids.difference(h5_ids)
+    missing_in_atlas = h5_ids.difference(atlas_ids)
+    if len(missing_in_h5) or len(missing_in_atlas):
+        raise AssertionError(
+            "ATLAS preprocess households CSV does not match the selected UrbanSim "
+            "H5 household table. This usually means cached/restored ATLAS inputs "
+            "belong to a different population universe. "
+            f"year={year} h5_path={h5_path} h5_table={h5_table_path} "
+            f"atlas_households_csv={households_csv} "
+            f"missing_in_h5={len(missing_in_h5)} "
+            f"missing_in_atlas={len(missing_in_atlas)} "
+            f"sample_missing_in_h5={missing_in_h5.tolist()[:10]} "
+            f"sample_missing_in_atlas={missing_in_atlas.tolist()[:10]}"
+        )
 
 
 @dataclass

--- a/pilates/beam/beam_input_staging.py
+++ b/pilates/beam/beam_input_staging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
@@ -14,17 +15,20 @@ from pilates.beam.config_hocon import (
     beam_primary_config_path,
     resolve_beam_config_value,
 )
+from pilates.beam.vehicle_source import resolve_atlas_vehicles2_source
 from pilates.generic.records import FileRecord, RecordStore
 from pilates.utils.beam_warmstart import resolve_initial_linkstats_path
 from pilates.utils.coupler_helpers import resolve_existing_path
 from pilates.utils.io import locate_beam_file
 from pilates.workflows.artifact_keys import (
+    ATLAS_VEHICLES2_OUTPUT,
     BEAM_HOUSEHOLDS_IN,
     BEAM_PERSONS_IN,
     BEAM_PLANS_IN,
 )
 
 logger = logging.getLogger(__name__)
+_VEHICLES2_NAME_RE = re.compile(r"^vehicles2_(?P<year>\d{4})\.csv(?:\.gz)?$")
 
 if TYPE_CHECKING:
     from pilates.workspace import Workspace
@@ -124,6 +128,7 @@ def copy_vehicles_from_atlas(
     state: Any,
     resolve_beam_exchange_scenario_folder_fn: Callable[[Any], str],
     source_path: Optional[str] = None,
+    require_exact_year: bool = False,
     preferred_format: Optional[str] = None,
 ) -> Optional[FileRecord]:
     beam_scenario_folder = resolve_beam_exchange_scenario_folder_fn(workspace)
@@ -134,19 +139,17 @@ def copy_vehicles_from_atlas(
         file_format=beam_vehicles_format,
     )
 
+    source_metadata: Dict[str, Any] = {}
     atlas_candidates = [source_path] if source_path else []
     if not atlas_candidates:
-        atlas_output_data_dir = workspace.get_atlas_output_dir()
-        atlas_candidates.extend(
-            [
-                os.path.join(
-                    atlas_output_data_dir, f"vehicles2_{state.forecast_year}.csv"
-                ),
-                os.path.join(
-                    atlas_output_data_dir, f"vehicles2_{state.forecast_year - 1}.csv"
-                ),
-            ]
+        resolved_source = resolve_atlas_vehicles2_source(
+            state=state,
+            workspace=workspace,
+            require_exact_year=require_exact_year,
         )
+        if resolved_source is not None:
+            atlas_candidates.append(str(resolved_source.selected_path))
+            source_metadata = resolved_source.as_input_metadata()
 
     atlas_vehicle_file_loc = None
     for candidate in atlas_candidates:
@@ -167,6 +170,31 @@ def copy_vehicles_from_atlas(
             atlas_candidates[0] if atlas_candidates else None,
         )
         return None
+
+    forecast_year = getattr(state, "forecast_year", None)
+    source_year = _source_year_from_vehicles2_path(atlas_vehicle_file_loc)
+    if require_exact_year and (
+        forecast_year is None or source_year != int(forecast_year)
+    ):
+        raise ValueError(
+            "BEAM preprocess requires exact forecast-year ATLAS vehicles2 input, "
+            f"but received source_path={atlas_vehicle_file_loc!r} "
+            f"forecast_year={forecast_year!r} parsed_source_year={source_year!r}."
+        )
+    if not source_metadata:
+        source_metadata = {
+            "source_semantic_key": ATLAS_VEHICLES2_OUTPUT,
+            "source_path": str(atlas_vehicle_file_loc),
+            "source_year": source_year,
+            "forecast_year": int(forecast_year) if forecast_year is not None else None,
+            "source_storage_location": "explicit",
+            "source_resolution_mode": (
+                "exact_forecast_year"
+                if forecast_year is not None and source_year == int(forecast_year)
+                else "explicit"
+            ),
+            "candidate_paths": [str(path) for path in atlas_candidates if path],
+        }
 
     logger.info(
         "Copying atlas vehicles2 file from %s to %s "
@@ -191,7 +219,15 @@ def copy_vehicles_from_atlas(
         short_name="vehicles_beam_in",
         year=getattr(state, "forecast_year", None),
         iteration=getattr(state, "current_inner_iter", None),
+        metadata=source_metadata,
     )
+
+
+def _source_year_from_vehicles2_path(path: str) -> Optional[int]:
+    match = _VEHICLES2_NAME_RE.match(Path(path).name)
+    if match is None:
+        return None
+    return int(match.group("year"))
 
 
 def validate_population_consistency(

--- a/pilates/beam/beam_input_staging.py
+++ b/pilates/beam/beam_input_staging.py
@@ -346,6 +346,76 @@ def validate_population_consistency(
     )
 
 
+def filter_vehicles_to_staged_households(
+    *,
+    workspace: Any,
+    settings: Any,
+    resolve_beam_exchange_scenario_folder_fn: Callable[[Any], str],
+    state: Any = None,
+) -> None:
+    beam_scenario_folder = resolve_beam_exchange_scenario_folder_fn(workspace)
+    file_format = settings.activitysim.file_format if settings.activitysim else "csv"
+    households_path = locate_beam_file(beam_scenario_folder, "households", file_format)
+    vehicles_path = _find_existing_vehicle_path(
+        beam_scenario_folder,
+        preferred_format=file_format,
+    )
+    if (
+        households_path is None
+        or not os.path.exists(households_path)
+        or vehicles_path is None
+        or not os.path.exists(vehicles_path)
+    ):
+        return
+
+    households = BeamDataHelper.read_and_clean(
+        households_path, "households", file_format
+    )
+    vehicles = _read_vehicle_table(vehicles_path)
+    vehicle_household_col = None
+    for candidate in ("householdId", "household_id"):
+        if candidate in vehicles.columns:
+            vehicle_household_col = candidate
+            break
+    if vehicle_household_col is None:
+        raise ValueError(
+            "BEAM staged vehicles input is missing a household reference column. "
+            f"Expected one of ['householdId', 'household_id'], found {vehicles.columns.tolist()}"
+        )
+
+    household_ids = _coerce_index_to_int64(
+        households.index,
+        context="staged households index",
+    )
+    vehicle_household_ids = _coerce_beam_vehicle_integer_column(
+        vehicles[vehicle_household_col],
+        column_name=vehicle_household_col,
+    )
+    keep_mask = vehicle_household_ids.isin(set(household_ids.values))
+    removed = int((~keep_mask).sum())
+    if removed == 0:
+        return
+
+    filtered = vehicles.loc[keep_mask].copy()
+    _write_vehicle_table(
+        filtered,
+        vehicles_path,
+        file_format=_vehicle_file_format_from_path(vehicles_path),
+    )
+    logger.warning(
+        "Filtered BEAM staged vehicles to ActivitySim-staged households. "
+        "workflow_year=%s forecast_year=%s iteration=%s removed_vehicle_rows=%s "
+        "remaining_vehicle_rows=%s households_path=%s vehicles_path=%s",
+        getattr(state, "year", None),
+        getattr(state, "forecast_year", None),
+        getattr(state, "current_inner_iter", None),
+        removed,
+        len(filtered),
+        households_path,
+        vehicles_path,
+    )
+
+
 def _beam_vehicle_file_format(preferred_format: Optional[str]) -> str:
     return "parquet" if preferred_format == "parquet" else "csv.gz"
 
@@ -388,6 +458,10 @@ def _write_vehicle_table(df: pd.DataFrame, path: str, *, file_format: str) -> No
         df.to_parquet(path, index=False)
         return
     df.to_csv(path, compression="gzip", index=False)
+
+
+def _vehicle_file_format_from_path(path: str) -> str:
+    return "parquet" if path.endswith(".parquet") else "csv.gz"
 
 
 def _normalize_beam_vehicle_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/pilates/beam/beam_input_staging.py
+++ b/pilates/beam/beam_input_staging.py
@@ -352,7 +352,7 @@ def filter_vehicles_to_staged_households(
     settings: Any,
     resolve_beam_exchange_scenario_folder_fn: Callable[[Any], str],
     state: Any = None,
-) -> None:
+) -> Dict[str, Any]:
     beam_scenario_folder = resolve_beam_exchange_scenario_folder_fn(workspace)
     file_format = settings.activitysim.file_format if settings.activitysim else "csv"
     households_path = locate_beam_file(beam_scenario_folder, "households", file_format)
@@ -366,7 +366,12 @@ def filter_vehicles_to_staged_households(
         or vehicles_path is None
         or not os.path.exists(vehicles_path)
     ):
-        return
+        return {
+            "filtered_to_staged_households": False,
+            "staged_household_filter_reason": "missing_staged_inputs",
+            "staged_household_filter_households_path": households_path,
+            "staged_household_filter_vehicles_path": vehicles_path,
+        }
 
     households = BeamDataHelper.read_and_clean(
         households_path, "households", file_format
@@ -393,8 +398,17 @@ def filter_vehicles_to_staged_households(
     )
     keep_mask = vehicle_household_ids.isin(set(household_ids.values))
     removed = int((~keep_mask).sum())
+    filter_metadata = {
+        "filtered_to_staged_households": True,
+        "staged_household_filter_input_vehicle_rows": len(vehicles),
+        "staged_household_filter_removed_vehicle_rows": removed,
+        "staged_household_filter_remaining_vehicle_rows": int(keep_mask.sum()),
+        "staged_household_filter_household_rows": len(households),
+        "staged_household_filter_households_path": households_path,
+        "staged_household_filter_vehicles_path": vehicles_path,
+    }
     if removed == 0:
-        return
+        return filter_metadata
 
     filtered = vehicles.loc[keep_mask].copy()
     _write_vehicle_table(
@@ -414,6 +428,7 @@ def filter_vehicles_to_staged_households(
         households_path,
         vehicles_path,
     )
+    return filter_metadata
 
 
 def _beam_vehicle_file_format(preferred_format: Optional[str]) -> str:

--- a/pilates/beam/beam_input_staging.py
+++ b/pilates/beam/beam_input_staging.py
@@ -20,6 +20,7 @@ from pilates.generic.records import FileRecord, RecordStore
 from pilates.utils.beam_warmstart import resolve_initial_linkstats_path
 from pilates.utils.coupler_helpers import resolve_existing_path
 from pilates.utils.io import locate_beam_file
+from pilates.workflows.state_helpers import resolve_forecast_year
 from pilates.workflows.artifact_keys import (
     ATLAS_VEHICLES2_OUTPUT,
     BEAM_HOUSEHOLDS_IN,
@@ -171,7 +172,7 @@ def copy_vehicles_from_atlas(
         )
         return None
 
-    forecast_year = getattr(state, "forecast_year", None)
+    forecast_year = resolve_forecast_year(state)
     source_year = _source_year_from_vehicles2_path(atlas_vehicle_file_loc)
     if require_exact_year and (
         forecast_year is None or source_year != int(forecast_year)

--- a/pilates/beam/outputs.py
+++ b/pilates/beam/outputs.py
@@ -125,6 +125,7 @@ class BeamPreprocessOutputs(StepOutputsBase):
     dict_path_fields: ClassVar[Tuple[str, ...]] = ("prepared_inputs",)
     beam_mutable_data_dir: Path
     prepared_inputs: Dict[str, Path] = field(default_factory=dict)
+    prepared_input_metadata: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     def _iter_record_items(self) -> Iterable[Tuple[str, Path, str]]:
         """
@@ -141,6 +142,7 @@ class BeamPreprocessOutputs(StepOutputsBase):
                     file_path=str(path),
                     short_name=short_name,
                     description=description,
+                    metadata=dict(self.prepared_input_metadata.get(short_name, {})),
                 )
                 for short_name, path, description in self._iter_record_items()
             ]
@@ -167,14 +169,22 @@ class BeamPreprocessOutputs(StepOutputsBase):
         """
         mapping = record_store.to_mapping()
         prepared_inputs: Dict[str, Path] = {}
+        prepared_input_metadata: Dict[str, Dict[str, Any]] = {}
         for key, value in mapping.items():
             path = artifact_to_path(value, workspace)
             if path is None:
                 continue
             prepared_inputs[key] = Path(path)
+        for record in record_store.all_records():
+            short_name = getattr(record, "short_name", None)
+            if short_name in prepared_inputs:
+                metadata = getattr(record, "metadata", None)
+                if metadata:
+                    prepared_input_metadata[short_name] = dict(metadata)
         return cls(
             beam_mutable_data_dir=Path(workspace.get_beam_mutable_data_dir()),
             prepared_inputs=prepared_inputs,
+            prepared_input_metadata=prepared_input_metadata,
         )
 
 

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -19,9 +19,9 @@ from pilates.beam.config_hocon import (
 )
 from pilates.beam import beam_input_staging
 from pilates.beam.outputs import BeamPreprocessOutputs
+from pilates.beam.vehicle_source import resolve_atlas_vehicles2_source
 from pilates.generic.preprocessor import GenericPreprocessor
 from pilates.generic.records import RecordStore, FileRecord
-from pilates.runtime.archive_paths import archive_fallback_path, first_existing_path
 from pilates.utils.coupler_helpers import artifact_to_path
 from pilates.utils.consist_runtime import artifact_fingerprint
 from pilates.utils.io import is_activity_demand_enabled
@@ -244,21 +244,16 @@ class BeamPreprocessor(GenericPreprocessor):
         )
         atlas_vehicle_input = None
         if atlas_output_dir is not None:
-            forecast_year = getattr(state, "forecast_year", None)
-            if forecast_year is not None:
-                for candidate in (
-                    Path(atlas_output_dir) / f"vehicles2_{forecast_year}.csv",
-                    Path(atlas_output_dir) / f"vehicles2_{forecast_year - 1}.csv",
-                ):
-                    archive_candidate = archive_fallback_path(
-                        state=state,
-                        workspace=workspace,
-                        local_path=candidate,
-                    )
-                    selected = first_existing_path(candidate, archive_candidate)
-                    if selected is not None:
-                        atlas_vehicle_input = str(selected)
-                        break
+            resolved_vehicle_source = resolve_atlas_vehicles2_source(
+                state=state,
+                workspace=workspace,
+                require_exact_year=(
+                    settings.runtime.flags.activity_demand_enabled
+                    and getattr(state, "current_inner_iter", 0) == 0
+                ),
+            )
+            if resolved_vehicle_source is not None:
+                atlas_vehicle_input = str(resolved_vehicle_source.selected_path)
         return {
             BEAM_MUTABLE_DATA_DIR: workspace.get_beam_mutable_data_dir(),
             BEAM_CONFIG_FILE: beam_config_path,
@@ -403,18 +398,24 @@ class BeamPreprocessor(GenericPreprocessor):
             self.settings.vehicle_ownership_model_enabled
             and self.state.current_inner_iter == 0
         ):
+            require_exact_vehicle_source = self._activity_demand_enabled()
+            source_short_names = (
+                (ATLAS_VEHICLES2_OUTPUT,)
+                if require_exact_vehicle_source
+                else (ATLAS_VEHICLES2_OUTPUT, "vehicles_beam_in")
+            )
             restored_vehicle_source = next(
                 (
                     record.file_path
                     for record in previous_records.all_records()
-                    if getattr(record, "short_name", None)
-                    in (ATLAS_VEHICLES2_OUTPUT, "vehicles_beam_in")
+                    if getattr(record, "short_name", None) in source_short_names
                 ),
                 None,
             )
             beam_output_record = self._copy_vehicles_from_atlas(
                 workspace,
                 source_path=restored_vehicle_source,
+                require_exact_year=require_exact_vehicle_source,
             )
             if beam_output_record is not None:
                 store.add_record(beam_output_record)
@@ -497,14 +498,23 @@ class BeamPreprocessor(GenericPreprocessor):
         )
         record_store = self._preprocess(workspace, input_store)
         prepared_inputs: Dict[str, Path] = {}
-        for key, value in record_store.to_mapping().items():
+        prepared_input_metadata: Dict[str, Dict[str, Any]] = {}
+        record_mapping = record_store.to_mapping()
+        for key, value in record_mapping.items():
             path = artifact_to_path(value, workspace)
             if path is None:
                 continue
             prepared_inputs[key] = Path(path)
+        for record in record_store.all_records():
+            short_name = getattr(record, "short_name", None)
+            if short_name in prepared_inputs:
+                metadata = getattr(record, "metadata", None)
+                if metadata:
+                    prepared_input_metadata[short_name] = dict(metadata)
         return BeamPreprocessOutputs(
             beam_mutable_data_dir=Path(workspace.get_beam_mutable_data_dir()),
             prepared_inputs=prepared_inputs,
+            prepared_input_metadata=prepared_input_metadata,
         )
 
     def copy_data_to_mutable_location(
@@ -595,12 +605,14 @@ class BeamPreprocessor(GenericPreprocessor):
         workspace: "Workspace",
         *,
         source_path: Optional[str] = None,
+        require_exact_year: bool = False,
     ) -> Optional[FileRecord]:
         return beam_input_staging.copy_vehicles_from_atlas(
             workspace=workspace,
             state=self.state,
             resolve_beam_exchange_scenario_folder_fn=self._resolve_beam_exchange_scenario_folder,
             source_path=source_path,
+            require_exact_year=require_exact_year,
             preferred_format=(
                 getattr(
                     getattr(self.settings, "activitysim", None), "file_format", None

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -26,6 +26,7 @@ from pilates.utils.coupler_helpers import artifact_to_path
 from pilates.utils.consist_runtime import artifact_fingerprint
 from pilates.utils.io import is_activity_demand_enabled
 from pilates.utils.path_utils import find_project_root
+from pilates.workflows.state_helpers import resolve_forecast_year
 from pilates.workflows.artifact_keys import (
     ASIM_OUTPUT_DIR,
     ATLAS_OUTPUT_DIR,
@@ -243,15 +244,19 @@ class BeamPreprocessor(GenericPreprocessor):
             else None
         )
         atlas_vehicle_input = None
-        if atlas_output_dir is not None:
-            resolved_vehicle_source = resolve_atlas_vehicles2_source(
-                state=state,
-                workspace=workspace,
-                require_exact_year=(
-                    settings.runtime.flags.activity_demand_enabled
-                    and getattr(state, "current_inner_iter", 0) == 0
-                ),
-            )
+        forecast_year = resolve_forecast_year(state)
+        if atlas_output_dir is not None and forecast_year is not None:
+            try:
+                resolved_vehicle_source = resolve_atlas_vehicles2_source(
+                    state=state,
+                    workspace=workspace,
+                    require_exact_year=(
+                        settings.runtime.flags.activity_demand_enabled
+                        and getattr(state, "current_inner_iter", 0) == 0
+                    ),
+                )
+            except FileNotFoundError:
+                resolved_vehicle_source = None
             if resolved_vehicle_source is not None:
                 atlas_vehicle_input = str(resolved_vehicle_source.selected_path)
         return {

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -21,6 +21,7 @@ from pilates.beam import beam_input_staging
 from pilates.beam.outputs import BeamPreprocessOutputs
 from pilates.generic.preprocessor import GenericPreprocessor
 from pilates.generic.records import RecordStore, FileRecord
+from pilates.runtime.archive_paths import archive_fallback_path, first_existing_path
 from pilates.utils.coupler_helpers import artifact_to_path
 from pilates.utils.consist_runtime import artifact_fingerprint
 from pilates.utils.io import is_activity_demand_enabled
@@ -246,13 +247,17 @@ class BeamPreprocessor(GenericPreprocessor):
             forecast_year = getattr(state, "forecast_year", None)
             if forecast_year is not None:
                 for candidate in (
-                    os.path.join(atlas_output_dir, f"vehicles2_{forecast_year}.csv"),
-                    os.path.join(
-                        atlas_output_dir, f"vehicles2_{forecast_year - 1}.csv"
-                    ),
+                    Path(atlas_output_dir) / f"vehicles2_{forecast_year}.csv",
+                    Path(atlas_output_dir) / f"vehicles2_{forecast_year - 1}.csv",
                 ):
-                    if os.path.exists(candidate):
-                        atlas_vehicle_input = candidate
+                    archive_candidate = archive_fallback_path(
+                        state=state,
+                        workspace=workspace,
+                        local_path=candidate,
+                    )
+                    selected = first_existing_path(candidate, archive_candidate)
+                    if selected is not None:
+                        atlas_vehicle_input = str(selected)
                         break
         return {
             BEAM_MUTABLE_DATA_DIR: workspace.get_beam_mutable_data_dir(),

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -392,6 +392,7 @@ class BeamPreprocessor(GenericPreprocessor):
             logger.info("No zones configured; skipping zone shapefile preparation.")
 
         store = RecordStore()
+        beam_output_record: Optional[FileRecord] = None
 
         # Copy vehicle data from Atlas (only on first iteration)
         if (
@@ -444,7 +445,9 @@ class BeamPreprocessor(GenericPreprocessor):
                     f"BEAM input trio, but missing outputs were {sorted(missing_keys)}"
                 )
             if self.state.current_inner_iter == 0:
-                self._filter_vehicles_to_staged_households(workspace)
+                filter_metadata = self._filter_vehicles_to_staged_households(workspace)
+                if beam_output_record is not None and filter_metadata:
+                    beam_output_record.metadata.update(filter_metadata)
                 self._validate_population_consistency(workspace)
         else:
             store += self._register_existing_beam_exchange_inputs(workspace)
@@ -716,8 +719,10 @@ class BeamPreprocessor(GenericPreprocessor):
             state=self.state,
         )
 
-    def _filter_vehicles_to_staged_households(self, workspace: "Workspace") -> None:
-        beam_input_staging.filter_vehicles_to_staged_households(
+    def _filter_vehicles_to_staged_households(
+        self, workspace: "Workspace"
+    ) -> Dict[str, Any]:
+        return beam_input_staging.filter_vehicles_to_staged_households(
             workspace=workspace,
             settings=self.settings,
             resolve_beam_exchange_scenario_folder_fn=self._resolve_beam_exchange_scenario_folder,

--- a/pilates/beam/preprocessor.py
+++ b/pilates/beam/preprocessor.py
@@ -444,6 +444,7 @@ class BeamPreprocessor(GenericPreprocessor):
                     f"BEAM input trio, but missing outputs were {sorted(missing_keys)}"
                 )
             if self.state.current_inner_iter == 0:
+                self._filter_vehicles_to_staged_households(workspace)
                 self._validate_population_consistency(workspace)
         else:
             store += self._register_existing_beam_exchange_inputs(workspace)
@@ -709,6 +710,14 @@ class BeamPreprocessor(GenericPreprocessor):
 
     def _validate_population_consistency(self, workspace: "Workspace") -> None:
         beam_input_staging.validate_population_consistency(
+            workspace=workspace,
+            settings=self.settings,
+            resolve_beam_exchange_scenario_folder_fn=self._resolve_beam_exchange_scenario_folder,
+            state=self.state,
+        )
+
+    def _filter_vehicles_to_staged_households(self, workspace: "Workspace") -> None:
+        beam_input_staging.filter_vehicles_to_staged_households(
             workspace=workspace,
             settings=self.settings,
             resolve_beam_exchange_scenario_folder_fn=self._resolve_beam_exchange_scenario_folder,

--- a/pilates/beam/vehicle_source.py
+++ b/pilates/beam/vehicle_source.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+from pilates.runtime.archive_paths import archive_fallback_path
+from pilates.utils.coupler_helpers import resolve_existing_path
+from pilates.workflows.artifact_keys import ATLAS_VEHICLES2_OUTPUT
+
+
+@dataclass(frozen=True)
+class AtlasVehicles2Source:
+    """Resolved ATLAS vehicles2 source for BEAM vehicle staging."""
+
+    selected_path: Path
+    forecast_year: int
+    source_year: int
+    storage_location: str
+    resolution_mode: str
+    candidates: Tuple[str, ...]
+
+    def as_input_metadata(self) -> dict[str, Any]:
+        return {
+            "source_semantic_key": ATLAS_VEHICLES2_OUTPUT,
+            "source_path": str(self.selected_path),
+            "source_year": self.source_year,
+            "forecast_year": self.forecast_year,
+            "source_storage_location": self.storage_location,
+            "source_resolution_mode": self.resolution_mode,
+            "candidate_paths": list(self.candidates),
+        }
+
+
+def _candidate_paths_for_year(
+    *,
+    state: Any,
+    workspace: Any,
+    source_year: int,
+) -> tuple[Path, Optional[Path]]:
+    local_path = Path(workspace.get_atlas_output_dir()) / f"vehicles2_{source_year}.csv"
+    archive_path = archive_fallback_path(
+        state=state,
+        workspace=workspace,
+        local_path=local_path,
+    )
+    return local_path, archive_path
+
+
+def resolve_atlas_vehicles2_source(
+    *,
+    state: Any,
+    workspace: Any,
+    require_exact_year: bool,
+) -> Optional[AtlasVehicles2Source]:
+    """Resolve the ATLAS vehicles2 source used to stage BEAM vehicles.
+
+    Exact mode accepts only ``vehicles2_{forecast_year}.csv``. Legacy mode tries
+    the forecast year first and then permits the prior forecast year fallback.
+    Both modes search the local run workspace before the archive fallback path.
+    """
+    forecast_year = getattr(state, "forecast_year", None)
+    if forecast_year is None:
+        if require_exact_year:
+            raise FileNotFoundError(
+                "BEAM preprocess requires forecast-year ATLAS vehicles2, but "
+                "WorkflowState.forecast_year is not set."
+            )
+        return None
+
+    forecast_year = int(forecast_year)
+    source_years = [forecast_year]
+    if not require_exact_year:
+        source_years.append(forecast_year - 1)
+
+    candidates: list[str] = []
+    for source_year in source_years:
+        local_path, archive_path = _candidate_paths_for_year(
+            state=state,
+            workspace=workspace,
+            source_year=source_year,
+        )
+        ordered = (("local", local_path), ("archive", archive_path))
+        for storage_location, candidate in ordered:
+            if candidate is None:
+                continue
+            candidates.append(str(candidate))
+            if candidate.exists():
+                return _resolved_source(
+                    selected_path=candidate,
+                    forecast_year=forecast_year,
+                    source_year=source_year,
+                    storage_location=storage_location,
+                    candidates=candidates,
+                )
+        env_resolved = resolve_existing_path(
+            str(local_path),
+            workspace=workspace,
+            materialize_from_archive=True,
+        )
+        if env_resolved:
+            resolved_path = Path(env_resolved)
+            candidates.append(str(resolved_path))
+            return _resolved_source(
+                selected_path=resolved_path,
+                forecast_year=forecast_year,
+                source_year=source_year,
+                storage_location=(
+                    "local" if resolved_path == local_path else "archive"
+                ),
+                candidates=candidates,
+            )
+
+    if require_exact_year:
+        raise FileNotFoundError(
+            "BEAM preprocess requires exact forecast-year ATLAS vehicles2, but "
+            f"vehicles2_{forecast_year}.csv was not found in local or archive "
+            f"candidates: {list(dict.fromkeys(candidates))}"
+        )
+    return None
+
+
+def _resolved_source(
+    *,
+    selected_path: Path,
+    forecast_year: int,
+    source_year: int,
+    storage_location: str,
+    candidates: list[str],
+) -> AtlasVehicles2Source:
+    return AtlasVehicles2Source(
+        selected_path=selected_path,
+        forecast_year=forecast_year,
+        source_year=source_year,
+        storage_location=storage_location,
+        resolution_mode=(
+            "exact_forecast_year"
+            if source_year == forecast_year
+            else "legacy_prior_year"
+        ),
+        candidates=tuple(dict.fromkeys(candidates)),
+    )

--- a/pilates/beam/vehicle_source.py
+++ b/pilates/beam/vehicle_source.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Tuple
 
 from pilates.runtime.archive_paths import archive_fallback_path
 from pilates.utils.coupler_helpers import resolve_existing_path
+from pilates.workflows.state_helpers import resolve_forecast_year
 from pilates.workflows.artifact_keys import ATLAS_VEHICLES2_OUTPUT
 
 
@@ -59,7 +60,7 @@ def resolve_atlas_vehicles2_source(
     the forecast year first and then permits the prior forecast year fallback.
     Both modes search the local run workspace before the archive fallback path.
     """
-    forecast_year = getattr(state, "forecast_year", None)
+    forecast_year = resolve_forecast_year(state)
     if forecast_year is None:
         if require_exact_year:
             raise FileNotFoundError(

--- a/pilates/runtime/consist_audit.py
+++ b/pilates/runtime/consist_audit.py
@@ -814,6 +814,7 @@ def _update_summary_state(state: Dict[str, Any], event: Mapping[str, Any]) -> No
             "used_cached_artifact_recovery",
             "used_manifest_restore",
             "used_compatibility_fallback",
+            "used_restart_rehydration",
         ):
             if bool(event.get(mode_field)):
                 state["steps_using_custom_recovery"][str(step_name)][mode_field] += 1

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -18,7 +18,10 @@ from pilates.config import PilatesConfig, load_config
 from pilates.runtime.consist_audit import emit_artifact_lifecycle_audit_event
 from pilates.utils import consist_runtime as cr
 from pilates.utils.consist_types import RunLike
-from pilates.utils.consist_db_snapshot import resolve_consist_db_paths
+from pilates.utils.consist_db_snapshot import (
+    resolve_consist_db_paths,
+    snapshot_latest_dir,
+)
 from sqlalchemy.exc import OperationalError
 
 logger = logging.getLogger(__name__)
@@ -188,6 +191,9 @@ def _archive_db_path(
     resolved = Path(archive_db_path)
     if resolved.exists():
         return resolved
+    latest_snapshot = snapshot_latest_dir(str(archive_run_dir)) / resolved.name
+    if latest_snapshot.exists():
+        return latest_snapshot
     return None
 
 

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -840,12 +840,17 @@ def promote_run_to_recovery_roots(
         tracker_db_path = getattr(working_tracker, "db_path", None)
         if tracker_db_path:
             try:
-                resolved_tracker_db_path = Path(
-                    os.path.expandvars(os.fspath(tracker_db_path))
-                ).expanduser().resolve()
+                resolved_tracker_db_path = (
+                    Path(os.path.expandvars(os.fspath(tracker_db_path)))
+                    .expanduser()
+                    .resolve()
+                )
             except OSError:
                 resolved_tracker_db_path = None
-            if resolved_tracker_db_path is not None and resolved_tracker_db_path != db_path:
+            if (
+                resolved_tracker_db_path is not None
+                and resolved_tracker_db_path != db_path
+            ):
                 refreshed_tracker = _open_archive_tracker(
                     settings,
                     archive_run_dir=source_run_dir,

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -551,7 +551,9 @@ def _sync_consist_state(source_run_dir: Path, destination_run_dir: Path) -> None
     shutil.copytree(source_consist_dir, destination_consist_dir, dirs_exist_ok=True)
     history_dir = destination_consist_dir / "snapshots" / "history"
     if history_dir.exists():
-        logger.info("Pruning excluded Consist snapshot history during sync: %s", history_dir)
+        logger.info(
+            "Pruning excluded Consist snapshot history during sync: %s", history_dir
+        )
         shutil.rmtree(history_dir, ignore_errors=True)
 
 
@@ -884,8 +886,8 @@ def promote_run_to_recovery_roots(
 
             try:
                 root_started = time.perf_counter()
-                source_file_count, source_dir_count, source_byte_count = _tree_inventory(
-                    source_run_dir
+                source_file_count, source_dir_count, source_byte_count = (
+                    _tree_inventory(source_run_dir)
                 )
                 logger.info(
                     "Promoting archive to recovery root %s -> %s "

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -831,6 +831,34 @@ def promote_run_to_recovery_roots(
 
     opened_tracker = None
     working_tracker = tracker or cr.current_tracker()
+    if (
+        working_tracker is not None
+        and db_path is not None
+        and not dry_run
+        and not verify_only
+    ):
+        tracker_db_path = getattr(working_tracker, "db_path", None)
+        if tracker_db_path:
+            try:
+                resolved_tracker_db_path = Path(
+                    os.path.expandvars(os.fspath(tracker_db_path))
+                ).expanduser().resolve()
+            except OSError:
+                resolved_tracker_db_path = None
+            if resolved_tracker_db_path is not None and resolved_tracker_db_path != db_path:
+                refreshed_tracker = _open_archive_tracker(
+                    settings,
+                    archive_run_dir=source_run_dir,
+                )
+                if refreshed_tracker is not None:
+                    logger.info(
+                        "Refreshing archive tracker from resolved DB path %s "
+                        "instead of stale tracker path %s",
+                        db_path,
+                        tracker_db_path,
+                    )
+                    working_tracker = refreshed_tracker
+                    opened_tracker = refreshed_tracker
     needs_tracker = (
         not dry_run
         and not verify_only

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -720,12 +720,24 @@ def promote_run_to_recovery_roots(
     dry_run: bool = False,
     verify_only: bool = False,
 ) -> PromotionResult:
+    overall_started = time.perf_counter()
     source_run_dir = _source_archive_run_dir(settings, archive_run_dir)
     recovery_roots = _recovery_roots(settings, roots=roots)
     db_path = _archive_db_path(settings, archive_run_dir=source_run_dir)
     require_consist_state = db_path is not None
     if merge_main_db is not None:
         merge_conflict = _validate_merge_conflict(merge_conflict)
+
+    logger.info(
+        "Starting archive promotion: source=%s recovery_roots=%d db_path=%s "
+        "dry_run=%s verify_only=%s merge_main_db=%s",
+        source_run_dir,
+        len(recovery_roots),
+        db_path if db_path is not None else "none",
+        dry_run,
+        verify_only,
+        merge_main_db if merge_main_db is not None else "none",
+    )
 
     result = PromotionResult(
         source_run_dir=str(source_run_dir),
@@ -791,15 +803,23 @@ def promote_run_to_recovery_roots(
                 continue
 
             try:
+                root_started = time.perf_counter()
+                logger.info(
+                    "Promoting archive to recovery root %s -> %s",
+                    recovery_root,
+                    destination_run_dir,
+                )
                 if dry_run:
                     entry.status = "dry_run"
                     continue
 
                 if not verify_only:
+                    logger.info("Copying archive tree to %s", destination_run_dir)
                     _copy_run_tree(source_run_dir, destination_run_dir)
                     entry.copy_performed = True
 
                 if verify:
+                    logger.info("Verifying promoted archive at %s", destination_run_dir)
                     _verify_promoted_run_dir(
                         source_run_dir=source_run_dir,
                         destination_run_dir=destination_run_dir,
@@ -808,6 +828,10 @@ def promote_run_to_recovery_roots(
                     entry.verified = True
 
                 if not verify_only and working_tracker is not None:
+                    logger.info(
+                        "Registering verified recovery copies for %s",
+                        destination_run_dir,
+                    )
                     metadata_updates = _register_verified_run_output_recovery_copies(
                         working_tracker,
                         source_run_dir=source_run_dir,
@@ -819,10 +843,19 @@ def promote_run_to_recovery_roots(
                 if not verify_only:
                     successful_destinations.append(destination_run_dir)
                     if working_tracker is not None:
+                        logger.info(
+                            "Syncing Consist state into %s",
+                            destination_run_dir,
+                        )
                         for successful_destination in successful_destinations:
                             _sync_consist_state(source_run_dir, successful_destination)
 
                 entry.status = "promoted"
+                logger.info(
+                    "Finished promotion for %s in %.2fs",
+                    destination_run_dir,
+                    time.perf_counter() - root_started,
+                )
             except Exception as exc:
                 entry.status = "failed"
                 entry.error = str(exc)
@@ -841,6 +874,12 @@ def promote_run_to_recovery_roots(
         ):
             if result.success:
                 try:
+                    merge_started = time.perf_counter()
+                    logger.info(
+                        "Exporting and merging root run subtree %s into %s",
+                        resolved_root_run_id,
+                        merge_main_db,
+                    )
                     result.merge_result = _merge_scoped_run_db_with_retry(
                         settings=settings,
                         source_tracker=working_tracker,
@@ -851,6 +890,10 @@ def promote_run_to_recovery_roots(
                         include_data=merge_include_data,
                         dry_run=merge_dry_run,
                         shard_path=merge_shard_path,
+                    )
+                    logger.info(
+                        "Finished Consist DB merge path in %.2fs",
+                        time.perf_counter() - merge_started,
                     )
                 except OperationalError as exc:
                     logger.warning(
@@ -897,6 +940,11 @@ def promote_run_to_recovery_roots(
                 artifact_metadata_updated=entry.artifact_metadata_updated,
                 db_path=str(db_path) if db_path is not None else None,
             )
+        logger.info(
+            "Archive promotion complete in %.2fs (success=%s)",
+            time.perf_counter() - overall_started,
+            result.success,
+        )
     finally:
         if opened_tracker is not None:
             _dispose_tracker(opened_tracker)

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -496,12 +496,13 @@ def _register_verified_run_output_recovery_copies(
     source_run_dir: Path,
     recovery_run_dir: Path,
     run_ids: Optional[Iterable[str]] = None,
+    verify: bool = True,
 ) -> int:
     register_copies = getattr(tracker, "register_run_output_recovery_copies", None)
     if not callable(register_copies):
         logger.warning(
             "Consist tracker does not expose register_run_output_recovery_copies; "
-            "skipping verified recovery-copy metadata registration."
+            "skipping recovery-copy metadata registration."
         )
         return 0
 
@@ -512,15 +513,19 @@ def _register_verified_run_output_recovery_copies(
     )
     registered = 0
     for run_id in selected_run_ids:
-        content_hashes = _run_output_content_hashes(
-            tracker,
-            source_run_dir=source_run_dir,
-            run_id=str(run_id),
+        content_hashes = (
+            _run_output_content_hashes(
+                tracker,
+                source_run_dir=source_run_dir,
+                run_id=str(run_id),
+            )
+            if verify
+            else {}
         )
         result = register_copies(
             str(run_id),
             str(recovery_run_dir),
-            verify=True,
+            verify=verify,
             append=True,
             content_hashes=content_hashes or None,
         )
@@ -529,8 +534,7 @@ def _register_verified_run_output_recovery_copies(
         blocked = getattr(result, "blocked", {})
         if blocked:
             logger.info(
-                "Verified recovery-copy registration blocked %d output(s) for "
-                "run %s: %s",
+                "Recovery-copy registration blocked %d output(s) for run %s: %s",
                 len(blocked),
                 run_id,
                 getattr(result, "summary", blocked),
@@ -786,6 +790,7 @@ def promote_run_to_recovery_roots(
     merge_dry_run: bool = False,
     merge_shard_path: Optional[str | os.PathLike[str]] = None,
     merge_only: bool = False,
+    recovery_copy_verify: bool = True,
     *,
     dry_run: bool = False,
     verify_only: bool = False,
@@ -802,7 +807,8 @@ def promote_run_to_recovery_roots(
 
     logger.info(
         "Starting archive promotion: source=%s recovery_roots=%d db_path=%s "
-        "dry_run=%s verify_only=%s merge_main_db=%s merge_only=%s",
+        "dry_run=%s verify_only=%s merge_main_db=%s merge_only=%s "
+        "recovery_copy_verify=%s",
         source_run_dir,
         len(recovery_roots),
         db_path if db_path is not None else "none",
@@ -810,6 +816,7 @@ def promote_run_to_recovery_roots(
         verify_only,
         merge_main_db if merge_main_db is not None else "none",
         merge_only,
+        recovery_copy_verify,
     )
 
     result = PromotionResult(
@@ -927,14 +934,16 @@ def promote_run_to_recovery_roots(
 
                 if not verify_only and working_tracker is not None:
                     logger.info(
-                        "Registering verified recovery copies for %s",
+                        "Registering recovery copies for %s (%sbyte verification)",
                         destination_run_dir,
+                        "with " if recovery_copy_verify else "without ",
                     )
                     metadata_updates = _register_verified_run_output_recovery_copies(
                         working_tracker,
                         source_run_dir=source_run_dir,
                         recovery_run_dir=destination_run_dir,
                         run_ids=scoped_run_ids or None,
+                        verify=recovery_copy_verify,
                     )
                     entry.artifact_metadata_updated = metadata_updates > 0
 
@@ -1115,6 +1124,16 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--no-recovery-copy-verify",
+        action="store_false",
+        dest="recovery_copy_verify",
+        default=True,
+        help=(
+            "Skip byte-level verification when registering promoted recovery copies "
+            "for this archive promotion."
+        ),
+    )
+    parser.add_argument(
         "--merge-only",
         action="store_true",
         help=(
@@ -1162,6 +1181,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         merge_include_data=bool(args.merge_include_data),
         merge_dry_run=bool(args.merge_dry_run),
         merge_only=bool(args.merge_only),
+        recovery_copy_verify=bool(args.recovery_copy_verify),
         merge_shard_path=args.merge_shard_path,
         dry_run=bool(args.dry_run),
         verify_only=bool(args.verify_only),

--- a/pilates/runtime/promote_run_archive.py
+++ b/pilates/runtime/promote_run_archive.py
@@ -135,9 +135,74 @@ def _recovery_roots(
     return resolved
 
 
+def _promotion_copy_ignore(
+    dirpath: str, names: list[str], *, source_run_dir: Path
+) -> set[str]:
+    try:
+        rel = Path(dirpath).relative_to(source_run_dir)
+    except ValueError:
+        return set()
+    if rel == Path("activitysim") / "output":
+        return {"final_pipeline"} if "final_pipeline" in names else set()
+    if rel == Path("shared_cache"):
+        return {"numba"} if "numba" in names else set()
+    if rel == Path(".consist") / "snapshots":
+        return {"history"} if "history" in names else set()
+    return set()
+
+
 def _copy_run_tree(source_run_dir: Path, destination_run_dir: Path) -> None:
+    source_run_dir = source_run_dir.resolve()
     destination_run_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source_run_dir, destination_run_dir, dirs_exist_ok=True)
+    if (source_run_dir / "activitysim" / "output" / "final_pipeline").exists():
+        logger.info("Skipping ActivitySim final_pipeline tree during promotion copy")
+    if (source_run_dir / "shared_cache" / "numba").exists():
+        logger.info("Skipping shared numba cache during promotion copy")
+    if (source_run_dir / ".consist" / "snapshots" / "history").exists():
+        logger.info("Skipping Consist snapshot history tree during promotion copy")
+    shutil.copytree(
+        source_run_dir,
+        destination_run_dir,
+        dirs_exist_ok=True,
+        ignore=lambda dirpath, names: _promotion_copy_ignore(
+            dirpath, names, source_run_dir=source_run_dir
+        ),
+    )
+    excluded_paths = [
+        destination_run_dir / "activitysim" / "output" / "final_pipeline",
+        destination_run_dir / "shared_cache" / "numba",
+        destination_run_dir / ".consist" / "snapshots" / "history",
+    ]
+    for excluded_path in excluded_paths:
+        if excluded_path.exists():
+            logger.info("Pruning excluded promotion tree: %s", excluded_path)
+            shutil.rmtree(excluded_path, ignore_errors=True)
+
+
+def _tree_inventory(root: Path) -> tuple[int, int, int]:
+    root = root.resolve()
+    file_count = 0
+    dir_count = 0
+    byte_count = 0
+    for current_root, dirs, files in os.walk(root):
+        try:
+            rel = Path(current_root).relative_to(root)
+        except ValueError:
+            rel = None
+        if rel == Path("activitysim") / "output" and "final_pipeline" in dirs:
+            dirs.remove("final_pipeline")
+        if rel == Path("shared_cache") and "numba" in dirs:
+            dirs.remove("numba")
+        if rel == Path(".consist") / "snapshots" and "history" in dirs:
+            dirs.remove("history")
+        dir_count += len(dirs)
+        file_count += len(files)
+        for name in files:
+            try:
+                byte_count += (Path(current_root) / name).stat().st_size
+            except OSError:
+                continue
+    return file_count, dir_count, byte_count
 
 
 def _verify_promoted_run_dir(
@@ -480,6 +545,10 @@ def _sync_consist_state(source_run_dir: Path, destination_run_dir: Path) -> None
     destination_consist_dir = destination_run_dir / ".consist"
     destination_consist_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source_consist_dir, destination_consist_dir, dirs_exist_ok=True)
+    history_dir = destination_consist_dir / "snapshots" / "history"
+    if history_dir.exists():
+        logger.info("Pruning excluded Consist snapshot history during sync: %s", history_dir)
+        shutil.rmtree(history_dir, ignore_errors=True)
 
 
 def _marker_path(source_run_dir: Path) -> Path:
@@ -716,6 +785,7 @@ def promote_run_to_recovery_roots(
     merge_include_data: bool = True,
     merge_dry_run: bool = False,
     merge_shard_path: Optional[str | os.PathLike[str]] = None,
+    merge_only: bool = False,
     *,
     dry_run: bool = False,
     verify_only: bool = False,
@@ -727,16 +797,19 @@ def promote_run_to_recovery_roots(
     require_consist_state = db_path is not None
     if merge_main_db is not None:
         merge_conflict = _validate_merge_conflict(merge_conflict)
+    if merge_only and merge_main_db is None:
+        raise ValueError("--merge-only requires --merge-main-db")
 
     logger.info(
         "Starting archive promotion: source=%s recovery_roots=%d db_path=%s "
-        "dry_run=%s verify_only=%s merge_main_db=%s",
+        "dry_run=%s verify_only=%s merge_main_db=%s merge_only=%s",
         source_run_dir,
         len(recovery_roots),
         db_path if db_path is not None else "none",
         dry_run,
         verify_only,
         merge_main_db if merge_main_db is not None else "none",
+        merge_only,
     )
 
     result = PromotionResult(
@@ -804,19 +877,44 @@ def promote_run_to_recovery_roots(
 
             try:
                 root_started = time.perf_counter()
+                source_file_count, source_dir_count, source_byte_count = _tree_inventory(
+                    source_run_dir
+                )
                 logger.info(
-                    "Promoting archive to recovery root %s -> %s",
+                    "Promoting archive to recovery root %s -> %s "
+                    "(files=%d dirs=%d size=%.2f GiB)",
                     recovery_root,
                     destination_run_dir,
+                    source_file_count,
+                    source_dir_count,
+                    source_byte_count / (1024**3),
                 )
                 if dry_run:
                     entry.status = "dry_run"
                     continue
 
-                if not verify_only:
-                    logger.info("Copying archive tree to %s", destination_run_dir)
+                if merge_only:
+                    if not destination_run_dir.exists():
+                        raise FileNotFoundError(
+                            "Cannot merge-only promote because the promoted archive "
+                            f"copy does not exist: {destination_run_dir}"
+                        )
+                    logger.info(
+                        "Reusing existing promoted archive copy at %s",
+                        destination_run_dir,
+                    )
+                elif not verify_only:
+                    logger.info(
+                        "Copying archive tree to %s with shutil.copytree(...)",
+                        destination_run_dir,
+                    )
                     _copy_run_tree(source_run_dir, destination_run_dir)
                     entry.copy_performed = True
+                    logger.info(
+                        "Finished copying archive tree to %s in %.2fs",
+                        destination_run_dir,
+                        time.perf_counter() - root_started,
+                    )
 
                 if verify:
                     logger.info("Verifying promoted archive at %s", destination_run_dir)
@@ -1017,6 +1115,14 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--merge-only",
+        action="store_true",
+        help=(
+            "Reuse an already-copied promoted archive and run only the Consist DB "
+            "export/merge path."
+        ),
+    )
+    parser.add_argument(
         "--merge-shard-path",
         help=(
             "Optional path for the filtered export shard used for a real merge. "
@@ -1055,6 +1161,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         merge_conflict=args.merge_conflict,
         merge_include_data=bool(args.merge_include_data),
         merge_dry_run=bool(args.merge_dry_run),
+        merge_only=bool(args.merge_only),
         merge_shard_path=args.merge_shard_path,
         dry_run=bool(args.dry_run),
         verify_only=bool(args.verify_only),

--- a/pilates/runtime/recovery_root_adoption.py
+++ b/pilates/runtime/recovery_root_adoption.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from pilates.runtime.archive_paths import archive_roots
+from pilates.utils import consist_runtime as cr
+from pilates.workflows.coupler_namespace import canonical_artifact_key_from_raw_key
+
+logger = logging.getLogger(__name__)
+
+CopySignature = tuple[int, int, bool]
+CopiedArtifact = tuple[str, str, str, bool, Optional[CopySignature]]
+
+_PHASE2_RECOVERY_ROOT_FAMILIES = {
+    "usim_input_archive",
+    "usim_population_source_h5",
+}
+
+_adoption_lock = threading.Lock()
+_last_copied_details: Dict[str, CopiedArtifact] = {}
+_last_registration_signature: Dict[str, CopySignature] = {}
+
+
+def reset_recovery_root_adoption_state() -> None:
+    with _adoption_lock:
+        _last_copied_details.clear()
+        _last_registration_signature.clear()
+
+
+def record_archive_copy(
+    *,
+    key: str,
+    src: str,
+    dest: str,
+    is_dir: bool,
+    signature: Optional[CopySignature],
+) -> None:
+    with _adoption_lock:
+        _last_copied_details[dest] = (key, src, dest, is_dir, signature)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _phase2_recovery_root_family(key: str) -> Optional[str]:
+    family = canonical_artifact_key_from_raw_key(key)
+    if family.startswith("usim_input_archive_"):
+        family = "usim_input_archive"
+    if family in _PHASE2_RECOVERY_ROOT_FAMILIES:
+        return family
+    return None
+
+
+def _content_hash_for_recovery_copy(artifact: Any, dest: str) -> str:
+    tracker = cr.current_tracker()
+    if (
+        tracker is not None
+        and getattr(getattr(tracker, "identity", None), "hashing_strategy", None)
+        == "full"
+    ):
+        artifact_hash = getattr(artifact, "hash", None)
+        if artifact_hash:
+            return str(artifact_hash)
+    return _sha256_file(Path(dest))
+
+
+def adopt_recovery_root_copy(
+    *,
+    key: str,
+    src: str,
+    dest: str,
+    is_dir: bool,
+    signature: Optional[CopySignature],
+    find_artifact: Callable[[str, str], Optional[Any]],
+    emit_lifecycle_event: Callable[..., None],
+) -> int:
+    family = _phase2_recovery_root_family(key)
+    if family is None:
+        return 0
+    if is_dir:
+        logger.debug(
+            "[Archive] Skipping phase 2 recovery-root adoption for directory copy: %s (key=%s)",
+            dest,
+            key,
+        )
+        return 0
+    if not os.path.isfile(dest):
+        logger.warning(
+            "[Archive] Skipping phase 2 recovery-root adoption for non-file copy: %s (key=%s)",
+            dest,
+            key,
+        )
+        return 0
+
+    artifact = find_artifact(key, src)
+    if artifact is None:
+        logger.debug(
+            "[Archive] No logged output artifact matched phase 2 recovery-root adoption for key=%s src=%s",
+            key,
+            src,
+        )
+        return 0
+
+    tracker = cr.current_tracker()
+    if tracker is None:
+        logger.debug(
+            "[Archive] No active tracker available for phase 2 recovery-root adoption (key=%s dest=%s)",
+            key,
+            dest,
+        )
+        return 0
+
+    register_copies = getattr(tracker, "register_run_output_recovery_copies", None)
+    if not callable(register_copies):
+        logger.warning(
+            "[Archive] Tracker does not expose register_run_output_recovery_copies; skipping phase 2 recovery-root adoption for key=%s",
+            key,
+        )
+        return 0
+
+    run_id = cr.current_run_id()
+    if not run_id:
+        logger.debug(
+            "[Archive] No active run id available for phase 2 recovery-root adoption (key=%s dest=%s)",
+            key,
+            dest,
+        )
+        return 0
+
+    roots = archive_roots()
+    if roots is None:
+        return 0
+    _local_root, archive_root = roots
+
+    with _adoption_lock:
+        if (
+            signature is not None
+            and _last_registration_signature.get(dest) == signature
+        ):
+            logger.debug(
+                "[Archive] Skipping duplicate phase 2 recovery-root adoption "
+                "(already registered): %s (key=%s)",
+                dest,
+                key,
+            )
+            return 0
+
+    content_hash = _content_hash_for_recovery_copy(artifact, dest)
+    result = register_copies(
+        str(run_id),
+        str(archive_root),
+        verify=True,
+        append=True,
+        content_hashes={str(key): content_hash},
+    )
+    registered = getattr(result, "registered", {}) or {}
+    blocked = getattr(result, "blocked", {}) or {}
+    if not registered:
+        if blocked:
+            logger.info(
+                "[Archive] Phase 2 recovery-root adoption blocked for key=%s: %s",
+                key,
+                getattr(result, "summary", blocked),
+            )
+        return 0
+
+    registered_count = len(registered)
+    with _adoption_lock:
+        if signature is not None:
+            _last_registration_signature[dest] = signature
+    logger.info(
+        "[Archive] Adopted phase 2 recovery root for key=%s run_id=%s root=%s registered=%d",
+        key,
+        run_id,
+        archive_root,
+        registered_count,
+    )
+    emit_lifecycle_event(
+        "archive_recovery_root_registered",
+        key=key,
+        src=src,
+        path=src,
+        dest=dest,
+        recovery_root=str(archive_root),
+        run_id=str(run_id),
+        artifact_family=family,
+        storage_event="local_to_scratch_recovery_root_adopted",
+        local_to_scratch_recovery_roots_written=registered_count,
+    )
+    return registered_count
+
+
+def adopt_pending_recovery_root_copies(
+    *,
+    find_artifact: Callable[[str, str], Optional[Any]],
+    emit_lifecycle_event: Callable[..., None],
+) -> int:
+    registered = 0
+    with _adoption_lock:
+        copied_details = list(_last_copied_details.items())
+    for dest, (key, src, recorded_dest, is_dir, signature) in copied_details:
+        if dest != recorded_dest:
+            continue
+        registered += adopt_recovery_root_copy(
+            key=key,
+            src=src,
+            dest=dest,
+            is_dir=is_dir,
+            signature=signature,
+            find_artifact=find_artifact,
+            emit_lifecycle_event=emit_lifecycle_event,
+        )
+    return registered

--- a/pilates/runtime/run_notifications.py
+++ b/pilates/runtime/run_notifications.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable, Mapping, Optional, Protocol, Sequence, Union
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -26,6 +27,15 @@ SlackBlock = dict[str, Union[str, SlackTextObject]]
 SlackPayload = dict[str, Union[str, list[SlackBlock]]]
 GoogleChatThread = dict[str, str]
 GoogleChatPayload = dict[str, Union[str, GoogleChatThread]]
+
+
+@dataclass
+class _RunThreadStats:
+    """Lightweight per-thread counters for a scenario recap."""
+
+    completed_steps: int = 0
+    cache_hits: int = 0
+    failures: int = 0
 
 
 class ConsistHookTracker(Protocol):
@@ -275,6 +285,7 @@ class ConsistRunNotifier:
         self.settings = settings
         self.backends = tuple(backends)
         self.context = context or RunNotificationContext()
+        self._thread_stats: dict[str, _RunThreadStats] = {}
 
     def on_run_start(self, run: Run) -> None:
         if not self._should_notify(run):
@@ -282,7 +293,7 @@ class ConsistRunNotifier:
         label = self._run_label(run)
         self._send(
             self._build_message(
-                title=f"{label} started",
+                title=_event_title("start", label, "started"),
                 run=run,
                 lines=self._run_lines(run, event="start"),
             )
@@ -292,27 +303,48 @@ class ConsistRunNotifier:
         if not self._should_notify(run):
             return
         label = self._run_label(run)
+        thread_key = _thread_key(context=self.context, run=run)
+        stats = self._thread_stats.setdefault(thread_key, _RunThreadStats())
+        cache_status = _cache_status(run, event="complete")
+        if not _is_scenario_header(run):
+            stats.completed_steps += 1
+            if cache_status == "cache hit":
+                stats.cache_hits += 1
+        lines = list(self._run_lines(run, event="complete", output_count=len(outputs)))
+        if _is_scenario_header(run):
+            recap_line = _scenario_recap_line(stats)
+            if recap_line is not None:
+                lines.append(recap_line)
         self._send(
             self._build_message(
-                title=f"{label} completed",
+                title=_event_title("complete", label, "completed"),
                 run=run,
-                lines=self._run_lines(run, event="complete", output_count=len(outputs)),
+                lines=tuple(lines),
             )
         )
+        if _is_scenario_header(run):
+            self._thread_stats.pop(thread_key, None)
 
     def on_run_failed(self, run: Run, error: Exception) -> None:
         label = self._run_label(run)
         error_text = self._truncate(str(error) or type(error).__name__)
+        thread_key = _thread_key(context=self.context, run=run)
+        stats = self._thread_stats.setdefault(thread_key, _RunThreadStats())
+        if not _is_scenario_header(run):
+            stats.failures += 1
         self._send(
             self._build_message(
-                title=f"{label} failed",
+                title=_event_title("failed", label, "failed"),
                 run=run,
                 lines=(
                     *self._run_lines(run, event="failed"),
                     f"error: {error_text}",
+                    _failure_next_step(self.context),
                 ),
             )
         )
+        if _is_scenario_header(run):
+            self._thread_stats.pop(thread_key, None)
 
     def _send(self, message: RunNotificationMessage) -> None:
         for backend in self.backends:
@@ -708,3 +740,32 @@ def _safe_request_error(exc: Exception) -> str:
     if isinstance(exc, requests.RequestException):
         return type(exc).__name__
     return str(exc)
+
+
+def _event_title(event: str, label: str, action: str) -> str:
+    prefix = {
+        "start": "🚀",
+        "complete": "✅",
+        "failed": "⚠️",
+    }.get(event)
+    title = f"{label} {action}"
+    return f"{prefix} {title}" if prefix else title
+
+
+def _scenario_recap_line(stats: _RunThreadStats) -> Optional[str]:
+    if not (stats.completed_steps or stats.cache_hits or stats.failures):
+        return None
+    return (
+        "Recap: "
+        f"{stats.completed_steps} step{'' if stats.completed_steps == 1 else 's'} completed, "
+        f"{stats.cache_hits} cache hit{'' if stats.cache_hits == 1 else 's'}, "
+        f"{stats.failures} failure{'' if stats.failures == 1 else 's'}"
+    )
+
+
+def _failure_next_step(context: RunNotificationContext) -> str:
+    base_dir = context.archive_run_dir or context.local_run_dir
+    if base_dir:
+        summary_path = Path(base_dir) / ".pilates" / "run_summary.html"
+        return f"Next: inspect `{summary_path}`"
+    return "Next: inspect the run archive and summary HTML"

--- a/pilates/utils/coupler_helpers.py
+++ b/pilates/utils/coupler_helpers.py
@@ -41,6 +41,7 @@ from pilates.runtime.archive_paths import (
     resolve_local_path as _resolve_local_path,
     resolve_workspace_uri_path as _resolve_workspace_uri_path,
 )
+from pilates.runtime import recovery_root_adoption
 
 logger = logging.getLogger(__name__)
 _STEP_OUTPUT_WARNING_SIGNATURES: set[tuple[Any, ...]] = set()
@@ -70,6 +71,9 @@ _archive_pending_tasks: Dict[
 _archive_queued_destinations: set[str] = set()
 _archive_inflight_signature: Dict[str, tuple[int, int, bool]] = {}
 _archive_last_copied_signature: Dict[str, tuple[int, int, bool]] = {}
+_archive_last_recovery_root_registration_signature = (
+    recovery_root_adoption._last_registration_signature
+)
 _published_coupler_keys: ContextVar[Optional[set[str]]] = ContextVar(
     "published_coupler_keys",
     default=None,
@@ -388,6 +392,16 @@ def _emit_artifact_lifecycle_event(
         logger.debug("Artifact lifecycle audit event failed", exc_info=True)
 
 
+def _register_phase2_recovery_root_copies() -> int:
+    return recovery_root_adoption.adopt_pending_recovery_root_copies(
+        find_artifact=lambda key, path: _find_current_run_output_artifact(
+            key=key,
+            path=path,
+        ),
+        emit_lifecycle_event=_emit_artifact_lifecycle_event,
+    )
+
+
 def _artifact_lifecycle_ids(artifact: Optional[Any]) -> Dict[str, Any]:
     try:
         run = cr.current_run()
@@ -470,6 +484,13 @@ def _copy_archive_payload(
             if _archive_inflight_signature.get(dest) == signature:
                 _archive_inflight_signature.pop(dest, None)
             _archive_last_copied_signature[dest] = signature
+    recovery_root_adoption.record_archive_copy(
+        key=key,
+        src=src,
+        dest=dest,
+        is_dir=is_dir,
+        signature=signature,
+    )
     _archive_log_method(key)("[Archive] Copied %s -> %s (key=%s)", src, dest, key)
     _emit_artifact_lifecycle_event(
         "archive_copy_completed",
@@ -721,6 +742,7 @@ def archive_copy_now(
             storage_event="local_to_scratch_copy_already_present",
             local_to_scratch_recovery_roots_written=0,
         )
+        _register_phase2_recovery_root_copies()
         return True
 
     _copy_archive_payload(
@@ -730,6 +752,7 @@ def archive_copy_now(
         is_dir=is_dir,
         signature=signature,
     )
+    _register_phase2_recovery_root_copies()
     return True
 
 
@@ -755,6 +778,7 @@ def flush_archive_queue(
     fail_on_timeout: bool = False,
 ) -> bool:
     if _archive_queue is None:
+        _register_phase2_recovery_root_copies()
         _emit_artifact_lifecycle_event(
             "archive_copy_checkpoint",
             require_existing_summary=True,
@@ -768,6 +792,7 @@ def flush_archive_queue(
     if timeout is None:
         _archive_queue.join()
         logger.info("[Archive] Flush complete")
+        _register_phase2_recovery_root_copies()
         _emit_artifact_lifecycle_event(
             "archive_copy_checkpoint",
             require_existing_summary=True,
@@ -780,6 +805,7 @@ def flush_archive_queue(
     while time.monotonic() < deadline:
         if _archive_queue.unfinished_tasks == 0:
             logger.info("[Archive] Flush complete")
+            _register_phase2_recovery_root_copies()
             _emit_artifact_lifecycle_event(
                 "archive_copy_checkpoint",
                 require_existing_summary=True,

--- a/pilates/utils/usim_h5.py
+++ b/pilates/utils/usim_h5.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from typing import Dict, Mapping, Optional
 
+import h5py
 import pandas as pd
 
 from pilates.workflows.artifact_keys import (
@@ -23,6 +24,41 @@ POPULATION_TABLE_BY_KEY: Dict[str, str] = {
     USIM_POPULATION_JOBS_TABLE: "jobs",
     USIM_POPULATION_BLOCKS_TABLE: "blocks",
 }
+
+
+def ensure_usim_population_year_table_aliases(
+    *,
+    h5_path: str,
+    year: int,
+) -> Dict[str, list[str]]:
+    """
+    Link root-level UrbanSim population tables into a year-scoped namespace.
+
+    UrbanSim forecast outputs can expose the current population slice at root
+    keys such as ``/households``. Downstream exact-year consumers expect
+    ``/<year>/households``. HDF5 hard links let the population-source snapshot
+    satisfy that contract without duplicating table data.
+    """
+    created: list[str] = []
+    existing: list[str] = []
+    missing_root: list[str] = []
+    with h5py.File(h5_path, "r+") as handle:
+        year_group = handle.require_group(str(year))
+        for table_name in POPULATION_TABLE_BY_KEY.values():
+            year_key = f"/{year}/{table_name}"
+            if table_name in year_group:
+                existing.append(year_key)
+                continue
+            if table_name not in handle:
+                missing_root.append(f"/{table_name}")
+                continue
+            year_group[table_name] = handle[table_name]
+            created.append(year_key)
+    return {
+        "created": created,
+        "existing": existing,
+        "missing_root": missing_root,
+    }
 
 
 def _year_from_usim_model_data_filename(h5_path: str) -> Optional[int]:

--- a/pilates/utils/usim_h5.py
+++ b/pilates/utils/usim_h5.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from pathlib import Path
-from typing import Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 import h5py
 import pandas as pd
@@ -131,6 +133,62 @@ def resolve_usim_h5_table_key(
             return min(year_scoped_candidates, key=lambda entry: entry[0])[1]
 
     return year_key
+
+
+def fingerprint_usim_h5_table(
+    *,
+    h5_path: str,
+    year: Optional[int],
+    table: str,
+    allow_root_fallback: bool = True,
+    nearest_year_fallback: bool = True,
+) -> Dict[str, Any]:
+    """
+    Return a stable semantic fingerprint for one UrbanSim H5 table.
+
+    The fingerprint is deliberately table-scoped instead of whole-file scoped:
+    ATLAS cache identity depends on the selected population table, not on
+    unrelated H5 metadata or tables that ATLAS does not consume for that
+    decision point.
+    """
+    with pd.HDFStore(h5_path, mode="r") as store:
+        table_path = resolve_usim_h5_table_key(
+            store,
+            year=year,
+            table=table,
+            allow_root_fallback=allow_root_fallback,
+            nearest_year_fallback=nearest_year_fallback,
+        )
+        if table_path not in store:
+            available = sorted(store.keys())
+            raise KeyError(
+                "UrbanSim H5 table fingerprint target is missing. "
+                f"h5_path={h5_path} year={year} table={table} "
+                f"resolved_table_path={table_path} available={available}"
+            )
+        frame = store[table_path]
+
+    metadata = {
+        "fingerprint_version": "usim_h5_table_v1",
+        "requested_year": year,
+        "table": table,
+        "resolved_table_path": table_path,
+        "row_count": int(len(frame)),
+        "column_count": int(len(frame.columns)),
+        "index_name": None if frame.index.name is None else str(frame.index.name),
+        "columns": [str(column) for column in frame.columns],
+        "dtypes": {str(column): str(dtype) for column, dtype in frame.dtypes.items()},
+    }
+    digest = hashlib.sha256()
+    digest.update(json.dumps(metadata, sort_keys=True).encode("utf-8"))
+    digest.update(b"\0")
+    row_hashes = pd.util.hash_pandas_object(frame, index=True).to_numpy(
+        dtype="uint64",
+        copy=False,
+    )
+    digest.update(row_hashes.tobytes())
+    metadata["sha256"] = digest.hexdigest()
+    return metadata
 
 
 def resolve_usim_population_table_paths(

--- a/pilates/workflows/binding.py
+++ b/pilates/workflows/binding.py
@@ -30,6 +30,7 @@ from typing import (
 
 from consist.types import BindingResult
 
+from pilates.beam.vehicle_source import resolve_atlas_vehicles2_source
 from pilates.runtime.archive_paths import archive_fallback_path, first_existing_path
 from pilates.utils.consist_types import CouplerProtocol
 from pilates.utils.coupler_helpers import (
@@ -467,11 +468,18 @@ def beam_preprocess_binding_plan(
             for key, value in warmstart_inputs.items():
                 explicit_inputs.setdefault(key, value)
 
+    require_exact_atlas_vehicles = bool(
+        resolved_profile.activity_demand_enabled
+        and activity_demand_outputs is not None
+        and resolved_profile.vehicle_ownership_model_enabled
+        and iteration_index(state, default=0) == 0
+    )
     atlas_inputs = _beam_preprocess_atlas_inputs(
         settings=settings,
         state=state,
         workspace=workspace,
         surface=surface,
+        require_exact_year=require_exact_atlas_vehicles,
     )
     # When BEAM is consuming the ActivitySim outputs from the current phase,
     # keep the ATLAS vehicles2 selection anchored to that same local year before
@@ -946,6 +954,7 @@ def _beam_preprocess_atlas_inputs(
     state: Any,
     workspace: Any,
     surface: "EnabledWorkflowSurface",
+    require_exact_year: bool = False,
     **_: Any,
 ) -> Optional[Mapping[str, Any]]:
     """Forecast-year ATLAS vehicles2 fallback.
@@ -963,24 +972,13 @@ def _beam_preprocess_atlas_inputs(
     if current_iter != 0:
         return None
 
-    forecast_year = getattr(state, "forecast_year", None)
-    if forecast_year is None:
-        return None
-
-    atlas_output_dir = workspace.get_atlas_output_dir()
-    candidates = [
-        Path(atlas_output_dir) / f"vehicles2_{forecast_year}.csv",
-        Path(atlas_output_dir) / f"vehicles2_{forecast_year - 1}.csv",
-    ]
-    for atlas_vehicle_path in candidates:
-        archive_path = archive_fallback_path(
-            state=state,
-            workspace=workspace,
-            local_path=atlas_vehicle_path,
-        )
-        selected = first_existing_path(atlas_vehicle_path, archive_path)
-        if selected is not None:
-            return {ATLAS_VEHICLES2_OUTPUT: str(selected)}
+    resolved = resolve_atlas_vehicles2_source(
+        state=state,
+        workspace=workspace,
+        require_exact_year=require_exact_year,
+    )
+    if resolved is not None:
+        return {ATLAS_VEHICLES2_OUTPUT: str(resolved.selected_path)}
     return None
 
 

--- a/pilates/workflows/binding.py
+++ b/pilates/workflows/binding.py
@@ -40,7 +40,10 @@ from pilates.utils.coupler_helpers import (
 from pilates.utils.beam_warmstart import resolve_initial_linkstats_path
 from pilates.utils.io import get_traffic_assignment_model
 from pilates.utils.state_access import iteration_index
-from pilates.utils.usim_h5 import resolve_usim_population_table_paths
+from pilates.utils.usim_h5 import (
+    ensure_usim_population_year_table_aliases,
+    resolve_usim_population_table_paths,
+)
 from pilates.workflows.state_helpers import resolve_forecast_year
 from pilates.workflows.artifact_keys import (
     ASIM_OMX_SKIMS,
@@ -765,18 +768,42 @@ def _activitysim_population_source(
         if isinstance(selected, (str, os.PathLike)):
             selected_path = os.fspath(selected)
             if os.path.exists(selected_path):
+                require_exact_year = _requires_exact_activitysim_population_year(state)
+                if (
+                    require_exact_year
+                    and target_year is not None
+                    and Path(selected_path).stem.endswith("_population_source")
+                ):
+                    try:
+                        alias_result = ensure_usim_population_year_table_aliases(
+                            h5_path=selected_path,
+                            year=target_year,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Failed to repair ActivitySim population-source year "
+                            "aliases for %s",
+                            selected_path,
+                            exc_info=True,
+                        )
+                    else:
+                        created = alias_result.get("created") or []
+                        if created:
+                            logger.info(
+                                "Added exact-year population table aliases for %s: %s",
+                                selected_path,
+                                created,
+                            )
                 try:
                     mapping.update(
                         resolve_usim_population_table_paths(
                             h5_path=selected_path,
                             year=target_year,
-                            require_exact_year=(
-                                _requires_exact_activitysim_population_year(state)
-                            ),
+                            require_exact_year=require_exact_year,
                         )
                     )
                 except Exception as exc:
-                    if _requires_exact_activitysim_population_year(state):
+                    if require_exact_year:
                         raise
                     logger.warning(
                         "Failed to resolve ActivitySim population-source table paths "

--- a/pilates/workflows/binding.py
+++ b/pilates/workflows/binding.py
@@ -969,12 +969,18 @@ def _beam_preprocess_atlas_inputs(
 
     atlas_output_dir = workspace.get_atlas_output_dir()
     candidates = [
-        os.path.join(atlas_output_dir, f"vehicles2_{forecast_year}.csv"),
-        os.path.join(atlas_output_dir, f"vehicles2_{forecast_year - 1}.csv"),
+        Path(atlas_output_dir) / f"vehicles2_{forecast_year}.csv",
+        Path(atlas_output_dir) / f"vehicles2_{forecast_year - 1}.csv",
     ]
     for atlas_vehicle_path in candidates:
-        if os.path.exists(atlas_vehicle_path):
-            return {ATLAS_VEHICLES2_OUTPUT: atlas_vehicle_path}
+        archive_path = archive_fallback_path(
+            state=state,
+            workspace=workspace,
+            local_path=atlas_vehicle_path,
+        )
+        selected = first_existing_path(atlas_vehicle_path, archive_path)
+        if selected is not None:
+            return {ATLAS_VEHICLES2_OUTPUT: str(selected)}
     return None
 
 

--- a/pilates/workflows/orchestration.py
+++ b/pilates/workflows/orchestration.py
@@ -1078,6 +1078,8 @@ def _publish_recovered_outputs(
 def _merge_output_recovery_meta(outputs: Any, audit_meta: Dict[str, Any]) -> None:
     if bool(getattr(outputs, "_compatibility_fallback_used", False)):
         audit_meta["used_compatibility_fallback"] = True
+    if bool(getattr(outputs, "_restart_rehydration_used", False)):
+        audit_meta["used_restart_rehydration"] = True
 
 
 def _finalize_recovered_step_outputs(

--- a/pilates/workflows/stages/land_use.py
+++ b/pilates/workflows/stages/land_use.py
@@ -40,6 +40,7 @@ from pilates.workflows.artifact_keys import (
 )
 from pilates.urbansim.inputs import build_urbansim_inputs
 from pilates.workflows.stages.handoffs import LandUseToSupplyDemandHandoff
+from pilates.utils.usim_h5 import ensure_usim_population_year_table_aliases
 
 logger = logging.getLogger(__name__)
 
@@ -240,6 +241,20 @@ def run_land_use_stage(
             forecast_output_path
         )
         shutil.copy2(forecast_output_path, population_source_snapshot)
+        if state.forecast_year is not None and not state.is_start_year():
+            alias_result = ensure_usim_population_year_table_aliases(
+                h5_path=str(population_source_snapshot),
+                year=state.forecast_year,
+            )
+            missing_root = alias_result.get("missing_root") or []
+            if missing_root:
+                logger.warning(
+                    "Population-source snapshot %s is missing root tables needed "
+                    "for year %s aliases: %s",
+                    population_source_snapshot,
+                    state.forecast_year,
+                    missing_root,
+                )
         usim_inputs[USIM_FORECAST_OUTPUT] = str(population_source_snapshot)
         usim_inputs[USIM_POPULATION_SOURCE_H5] = str(population_source_snapshot)
     if postprocess_outputs is not None and postprocess_outputs.usim_datastore_h5:

--- a/pilates/workflows/stages/vehicle_ownership.py
+++ b/pilates/workflows/stages/vehicle_ownership.py
@@ -561,6 +561,10 @@ def run_vehicle_ownership_stage(
                         USIM_POPULATION_SOURCE_H5,
                         str(atlas_postprocess_outputs.usim_datastore_h5),
                     )
+                    set_value(
+                        USIM_DATASTORE_CURRENT_H5,
+                        str(atlas_postprocess_outputs.usim_datastore_h5),
+                    )
                 if not atlas_state.is_start_year():
                     _validate_population_h5_for_activitysim_year(
                         path=atlas_postprocess_outputs.usim_datastore_h5,

--- a/pilates/workflows/step_consist_meta.py
+++ b/pilates/workflows/step_consist_meta.py
@@ -138,6 +138,63 @@ def consist_step_meta(model: str) -> Dict[str, Any]:
     def _workspace_path(ctx: StepContext) -> Optional[str]:
         return _workspace_path_from_value(_workspace(ctx))
 
+    def _state_is_start_year(state: Any) -> bool:
+        is_start_year = getattr(state, "is_start_year", None)
+        if callable(is_start_year):
+            try:
+                return bool(is_start_year())
+            except TypeError:
+                pass
+        year = getattr(state, "year", None)
+        start_year = getattr(state, "start_year", None)
+        return (
+            year is not None and start_year is not None and int(year) == int(start_year)
+        )
+
+    def _atlas_selected_usim_h5(state: Any) -> Any:
+        current_h5 = getattr(state, "atlas_usim_datastore_h5", None)
+        base_h5 = getattr(state, "atlas_usim_datastore_base_h5", None)
+        if _state_is_start_year(state) and base_h5 is not None:
+            return base_h5
+        return current_h5 if current_h5 is not None else base_h5
+
+    def _atlas_usim_households_identity(ctx: StepContext) -> Dict[str, Any]:
+        state = _state(ctx)
+        if state is None:
+            return {}
+        selected_h5 = _atlas_selected_usim_h5(state)
+        if selected_h5 is None:
+            return {}
+
+        from pilates.utils.coupler_helpers import artifact_to_existing_path
+        from pilates.utils.usim_h5 import fingerprint_usim_h5_table
+
+        workspace_obj = _workspace(ctx)
+        h5_path = artifact_to_existing_path(selected_h5, workspace=workspace_obj)
+        if h5_path is None:
+            return {
+                "atlas_usim_households_identity_status": "unresolved",
+                "atlas_usim_households_source": str(selected_h5),
+            }
+
+        year = getattr(state, "year", getattr(state, "current_year", None))
+        fingerprint = fingerprint_usim_h5_table(
+            h5_path=h5_path,
+            year=int(year) if year is not None else None,
+            table="households",
+        )
+        return {
+            "atlas_usim_households_identity_status": "resolved",
+            "atlas_usim_households_fingerprint_version": fingerprint[
+                "fingerprint_version"
+            ],
+            "atlas_usim_households_sha256": fingerprint["sha256"],
+            "atlas_usim_households_requested_year": fingerprint["requested_year"],
+            "atlas_usim_households_table_path": fingerprint["resolved_table_path"],
+            "atlas_usim_households_row_count": fingerprint["row_count"],
+            "atlas_usim_households_column_count": fingerprint["column_count"],
+        }
+
     def _activitysim_adapter(ctx: StepContext) -> Any:
         settings = _settings(ctx)
         if settings is None:
@@ -372,6 +429,7 @@ def consist_step_meta(model: str) -> Dict[str, Any]:
                 main_forecast_year = getattr(state, "main_forecast_year", None)
                 if main_forecast_year is not None:
                     atlas_runtime_identity["main_forecast_year"] = main_forecast_year
+                atlas_runtime_identity.update(_atlas_usim_households_identity(ctx))
             if atlas_runtime_identity:
                 resolved["config"] = {
                     **dict(resolved.get("config") or {}),

--- a/pilates/workflows/steps/beam.py
+++ b/pilates/workflows/steps/beam.py
@@ -30,6 +30,7 @@ from pilates.beam.config_hocon import (
 from pilates.config.models import PilatesConfig
 from pilates.utils.coupler_helpers import artifact_to_existing_path
 from pilates.workflows.artifact_keys import (
+    ATLAS_VEHICLES2_OUTPUT,
     BEAM_CONFIG_FILE,
     BEAM_HOUSEHOLDS_IN,
     BEAM_INPUT_CONFIG_ARCHIVED,
@@ -201,6 +202,34 @@ _BEAM_RUN_ARCHIVE_SOURCE_ROLE_MAP: Dict[str, str] = {
         "beam_experienced_plans_warmstart"
     ),
 }
+
+
+def _beam_preprocess_input_publication_meta(
+    *,
+    key: str,
+    state: WorkflowState,
+    input_metadata: Mapping[str, Any],
+) -> Dict[str, Any]:
+    if key != "vehicles_beam_in":
+        return {}
+    if input_metadata.get("source_semantic_key") != ATLAS_VEHICLES2_OUTPUT:
+        return {}
+
+    return {
+        "facet": {
+            "artifact_family": "beam_preprocess_input",
+            "source_role": key,
+            "derived_from": ATLAS_VEHICLES2_OUTPUT,
+            "year": getattr(state, "forecast_year", None),
+            "iteration": getattr(state, "iteration", None),
+            "source_year": input_metadata.get("source_year"),
+            "source_resolution_mode": input_metadata.get("source_resolution_mode"),
+            "source_storage_location": input_metadata.get("source_storage_location"),
+        },
+        "facet_schema_version": "v1",
+        "facet_index": True,
+        "source_path": input_metadata.get("source_path"),
+    }
 
 
 def _beam_run_snapshot_dir(
@@ -847,8 +876,9 @@ def _recover_beam_preprocess_outputs(
     cached_outputs: Optional[Mapping[str, Any]],
     run_id: Optional[str],
 ) -> Optional[BeamPreprocessOutputs]:
-    del settings, state, coupler, outputs_holder, cached_outputs, run_id
+    del settings, state, coupler, outputs_holder, run_id
     prepared_inputs: Dict[str, Path] = {}
+    prepared_input_metadata: Dict[str, Dict[str, Any]] = {}
     if step_inputs:
         allowed_keys = {
             BEAM_CONFIG_FILE,
@@ -870,9 +900,16 @@ def _recover_beam_preprocess_outputs(
                 prepared_inputs[key] = Path(path)
     if not prepared_inputs:
         return None
+    if cached_outputs:
+        raw_metadata = cached_outputs.get("prepared_input_metadata")
+        if isinstance(raw_metadata, Mapping):
+            for key, value in raw_metadata.items():
+                if key in prepared_inputs and isinstance(value, Mapping):
+                    prepared_input_metadata[str(key)] = dict(value)
     return BeamPreprocessOutputs(
         beam_mutable_data_dir=Path(workspace.get_beam_mutable_data_dir()),
         prepared_inputs=prepared_inputs,
+        prepared_input_metadata=prepared_input_metadata,
     )
 
 
@@ -1081,6 +1118,13 @@ def make_beam_preprocess_step(
                 "plans_beam_in",
                 "vehicles_beam_in",
             },
+            extra_meta_fn=lambda key, _path, _description: (
+                _beam_preprocess_input_publication_meta(
+                    key=key,
+                    state=state,
+                    input_metadata=outputs.prepared_input_metadata.get(key, {}),
+                )
+            ),
         )
 
     step = build_standard_step(

--- a/pilates/workflows/steps/beam.py
+++ b/pilates/workflows/steps/beam.py
@@ -215,17 +215,25 @@ def _beam_preprocess_input_publication_meta(
     if input_metadata.get("source_semantic_key") != ATLAS_VEHICLES2_OUTPUT:
         return {}
 
+    facet = {
+        "artifact_family": "beam_preprocess_input",
+        "source_role": key,
+        "derived_from": ATLAS_VEHICLES2_OUTPUT,
+        "year": getattr(state, "forecast_year", None),
+        "iteration": getattr(state, "iteration", None),
+        "source_year": input_metadata.get("source_year"),
+        "source_resolution_mode": input_metadata.get("source_resolution_mode"),
+        "source_storage_location": input_metadata.get("source_storage_location"),
+    }
+    for optional_key in (
+        "filtered_to_staged_households",
+        "staged_household_filter_removed_vehicle_rows",
+    ):
+        if optional_key in input_metadata:
+            facet[optional_key] = input_metadata.get(optional_key)
+
     return {
-        "facet": {
-            "artifact_family": "beam_preprocess_input",
-            "source_role": key,
-            "derived_from": ATLAS_VEHICLES2_OUTPUT,
-            "year": getattr(state, "forecast_year", None),
-            "iteration": getattr(state, "iteration", None),
-            "source_year": input_metadata.get("source_year"),
-            "source_resolution_mode": input_metadata.get("source_resolution_mode"),
-            "source_storage_location": input_metadata.get("source_storage_location"),
-        },
+        "facet": facet,
         "facet_schema_version": "v1",
         "facet_index": True,
         "source_path": input_metadata.get("source_path"),

--- a/pilates/workflows/steps/urbansim_atlas.py
+++ b/pilates/workflows/steps/urbansim_atlas.py
@@ -935,7 +935,7 @@ def make_atlas_preprocess_step(
     ) -> None:
         setattr(
             outputs,
-            "_compatibility_fallback_used",
+            "_restart_rehydration_used",
             _rehydrate_restart_atlas_preprocess_state(
                 state=state,
                 workspace=workspace,

--- a/pilates/workflows/steps/urbansim_atlas.py
+++ b/pilates/workflows/steps/urbansim_atlas.py
@@ -144,6 +144,25 @@ def _resolve_atlas_postprocess_households_table_path(
     return resolved if str(resolved).startswith("/") else f"/{resolved}"
 
 
+def _atlas_postprocess_output_meta(
+    *,
+    key: str,
+    state: WorkflowState,
+) -> Dict[str, Any]:
+    if key != ATLAS_VEHICLES2_OUTPUT:
+        return {}
+    return {
+        "facet": {
+            "artifact_family": ATLAS_VEHICLES2_OUTPUT,
+            "source_role": ATLAS_VEHICLES2_OUTPUT,
+            "year": getattr(state, "forecast_year", None),
+            "iteration": getattr(state, "iteration", None),
+        },
+        "facet_schema_version": "v1",
+        "facet_index": True,
+    }
+
+
 def _urbansim_run_recovered_datastore(
     recovered_paths: Mapping[str, Path], _state: WorkflowState
 ) -> Optional[Path]:
@@ -1153,6 +1172,9 @@ def make_atlas_postprocess_step(
                 **meta,
             ),
             profile_schema_suffixes=(".csv", ".parquet"),
+            extra_meta_fn=lambda key, _path, _description: (
+                _atlas_postprocess_output_meta(key=key, state=state)
+            ),
         )
         if outputs.usim_datastore_h5 is not None:
             if not state.is_start_year():

--- a/pilates/workflows/steps/urbansim_atlas.py
+++ b/pilates/workflows/steps/urbansim_atlas.py
@@ -19,6 +19,7 @@ from pilates.urbansim.postprocessor import UrbansimPostprocessor
 from pilates.urbansim.preprocessor import UrbansimPreprocessor
 from pilates.urbansim.runner import UrbansimRunner
 from pilates.utils.coupler_helpers import artifact_to_existing_path
+from pilates.utils.usim_h5 import ensure_usim_population_year_table_aliases
 from pilates.workflows.artifact_keys import (
     ATLAS_VEHICLES2_OUTPUT,
     USIM_POPULATION_SOURCE_H5,
@@ -1154,6 +1155,18 @@ def make_atlas_postprocess_step(
             profile_schema_suffixes=(".csv", ".parquet"),
         )
         if outputs.usim_datastore_h5 is not None:
+            if not state.is_start_year():
+                try:
+                    ensure_usim_population_year_table_aliases(
+                        h5_path=str(outputs.usim_datastore_h5),
+                        year=forecast_year,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to normalize ATLAS population-source H5 aliases for %s",
+                        outputs.usim_datastore_h5,
+                        exc_info=True,
+                    )
             households_table_path = _resolve_atlas_postprocess_households_table_path(
                 path=str(outputs.usim_datastore_h5),
                 forecast_year=forecast_year,

--- a/tests/test_activitysim_postprocessor_person_household_id.py
+++ b/tests/test_activitysim_postprocessor_person_household_id.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pandas.testing as pdt
 
 from pilates.activitysim.postprocessor import (
+    _next_iter_usim_input_store_path,
     _prepare_updated_tables,
     create_usim_input_data,
 )
@@ -21,6 +22,21 @@ def _settings(vehicle_ownership=None):
             region_mappings={"region_to_region_id": {"test": "001"}},
         ),
     )
+
+
+def test_next_iter_usim_input_store_path_uses_mutable_input_not_forecast_output(
+    tmp_path,
+):
+    workspace = SimpleNamespace(
+        get_usim_mutable_data_dir=lambda: str(tmp_path / "urbansim" / "data")
+    )
+    settings = _settings()
+    state = SimpleNamespace(forecast_year=2021)
+
+    path = _next_iter_usim_input_store_path(settings, workspace, state)
+
+    assert path == str(tmp_path / "urbansim" / "data" / "custom_mpo_001_model_data.h5")
+    assert not path.endswith("model_data_2021.h5")
 
 
 def test_prepare_updated_tables_preserves_usim_person_household_ids_when_asim_ids_are_invalid(

--- a/tests/test_activitysim_preprocessor_config_dirs.py
+++ b/tests/test_activitysim_preprocessor_config_dirs.py
@@ -1,8 +1,13 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+import yaml
 
-from pilates.activitysim.preprocessor import _ensure_required_asim_config_dirs
+from pilates.activitysim.preprocessor import (
+    _disable_activitysim_vehicle_ownership_models_for_atlas,
+    _ensure_required_asim_config_dirs,
+)
 
 
 def test_ensure_required_asim_config_dirs_synthesizes_missing_overlays(
@@ -39,3 +44,70 @@ def test_ensure_required_asim_config_dirs_raises_without_any_base_dir(
             configs_dest_dir=str(configs_dest_dir),
             main_configs_dir="configs",
         )
+
+
+def test_disable_activitysim_vehicle_ownership_models_for_atlas(tmp_path: Path) -> None:
+    configs_dest_dir = tmp_path / "configs_mutable"
+    config_dir = configs_dest_dir / "configs"
+    mp_dir = configs_dest_dir / "configs_mp"
+    config_dir.mkdir(parents=True)
+    mp_dir.mkdir(parents=True)
+    for directory in (config_dir, mp_dir):
+        (directory / "settings.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "models": [
+                        "initialize_landuse",
+                        "auto_ownership_simulate",
+                        "mandatory_tour_frequency",
+                        "vehicle_type_choice",
+                    ],
+                    "chunk_size": 0,
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+    settings = SimpleNamespace(
+        run=SimpleNamespace(models=SimpleNamespace(vehicle_ownership="atlas"))
+    )
+
+    removed = _disable_activitysim_vehicle_ownership_models_for_atlas(
+        settings=settings,
+        configs_dest_dir=str(configs_dest_dir),
+        main_configs_dir="configs",
+    )
+
+    assert set(removed) == {
+        str(config_dir / "settings.yaml"),
+        str(mp_dir / "settings.yaml"),
+    }
+    updated = yaml.safe_load((config_dir / "settings.yaml").read_text(encoding="utf-8"))
+    assert updated["models"] == ["initialize_landuse", "mandatory_tour_frequency"]
+    assert updated["chunk_size"] == 0
+
+
+def test_disable_activitysim_vehicle_ownership_models_skips_non_atlas(
+    tmp_path: Path,
+) -> None:
+    configs_dest_dir = tmp_path / "configs_mutable"
+    config_dir = configs_dest_dir / "configs"
+    config_dir.mkdir(parents=True)
+    settings_path = config_dir / "settings.yaml"
+    settings_path.write_text(
+        yaml.safe_dump({"models": ["auto_ownership_simulate"]}),
+        encoding="utf-8",
+    )
+    settings = SimpleNamespace(
+        run=SimpleNamespace(models=SimpleNamespace(vehicle_ownership=None))
+    )
+
+    removed = _disable_activitysim_vehicle_ownership_models_for_atlas(
+        settings=settings,
+        configs_dest_dir=str(configs_dest_dir),
+        main_configs_dir="configs",
+    )
+
+    assert removed == {}
+    updated = yaml.safe_load(settings_path.read_text(encoding="utf-8"))
+    assert updated["models"] == ["auto_ownership_simulate"]

--- a/tests/test_archive_copy_workflow.py
+++ b/tests/test_archive_copy_workflow.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
+import hashlib
 import json
 import logging
 import queue
@@ -70,6 +71,7 @@ def _reset_archive_state(monkeypatch):
     ch._archive_queued_destinations.clear()
     ch._archive_inflight_signature.clear()
     ch._archive_last_copied_signature.clear()
+    ch.recovery_root_adoption.reset_recovery_root_adoption_state()
     consist_audit.reset_consist_audit_state()
     monkeypatch.delenv("PILATES_ENABLE_ARCHIVE_COPY", raising=False)
     monkeypatch.delenv("PILATES_LOCAL_RUN_DIR", raising=False)
@@ -82,6 +84,7 @@ def _reset_archive_state(monkeypatch):
     ch._archive_queued_destinations.clear()
     ch._archive_inflight_signature.clear()
     ch._archive_last_copied_signature.clear()
+    ch.recovery_root_adoption.reset_recovery_root_adoption_state()
     consist_audit.reset_consist_audit_state()
 
 
@@ -714,6 +717,214 @@ def test_artifact_lifecycle_summary_starts_h5_phase2_eligibility(
     assert family in summary["phase2_candidate_families"]
     assert family in summary["safe_families_for_phase2"]
     assert family not in summary["blocked_families_for_phase2"]
+
+
+@pytest.mark.parametrize(
+    "key, family, artifact_meta, expected_safe_families",
+    [
+        (
+            "usim_input_archive_2030",
+            "usim_input_archive",
+            {
+                "source_role": "usim_datastore_h5",
+                "snapshot_role": "usim_input_archive",
+                "snapshot_reason": "pre_merge_input",
+                "storage_event": "snapshot_move",
+            },
+            ["usim_input_archive"],
+        ),
+        (
+            "usim_population_source_h5",
+            "usim_population_source_h5",
+            {
+                "source_role": "usim_population_source_h5",
+                "snapshot_role": "usim_population_source_h5",
+                "snapshot_reason": "post_merge_handoff",
+                "storage_event": "merged_h5_output",
+            },
+            ["usim_population_source_h5"],
+        ),
+    ],
+)
+def test_phase2_recovery_root_registration_adopts_only_narrow_h5_families(
+    monkeypatch, tmp_path, key, family, artifact_meta, expected_safe_families
+):
+    local_root = tmp_path / "local" / "run"
+    archive_root = tmp_path / "archive" / "run"
+    monkeypatch.setenv("PILATES_ENABLE_ARCHIVE_COPY", "1")
+    monkeypatch.setenv("PILATES_LOCAL_RUN_DIR", str(local_root))
+    monkeypatch.setenv("PILATES_ARCHIVE_RUN_DIR", str(archive_root))
+
+    registration_calls = []
+    tracker = SimpleNamespace(
+        register_run_output_recovery_copies=lambda run_id, recovery_root, **kwargs: (
+            registration_calls.append((run_id, recovery_root, kwargs))
+            or SimpleNamespace(
+                registered={key: object()},
+                blocked={},
+                summary="registered=1",
+            )
+        ),
+    )
+    monkeypatch.setattr(ch.cr, "current_tracker", lambda: tracker)
+    monkeypatch.setattr(ch.cr, "current_run", lambda: SimpleNamespace(id="run-123"))
+    monkeypatch.setattr(ch.cr, "current_run_id", lambda: "run-123")
+    monkeypatch.setattr(
+        ch,
+        "_find_current_run_output_artifact",
+        lambda *, key, path: SimpleNamespace(key=key, container_uri=str(path)),
+    )
+
+    source = local_root / "urbansim" / "data" / "model_data_2030.h5"
+    _write_file(source, "h5")
+    consist_audit.emit_artifact_lifecycle_audit_event(
+        event_type="artifact_logged",
+        key=key,
+        path=str(source),
+        artifact_family=family,
+        **artifact_meta,
+        year=2030,
+        h5_container=True,
+        container_recovery_unit="parent_file",
+        child_recovery_policy="descriptive_only",
+    )
+    assert ch.archive_copy_now(key=key, path=str(source))
+
+    expected_hash = hashlib.sha256(b"h5").hexdigest()
+    assert registration_calls == [
+        (
+            "run-123",
+            str(archive_root),
+            {
+                "append": True,
+                "content_hashes": {key: expected_hash},
+                "verify": True,
+            },
+        )
+    ]
+
+    summary = _lifecycle_summary(local_root)
+    assert summary["local_to_scratch_recovery_roots_written"] == 1
+    assert summary["phase2_candidate_families"] == [
+        "usim_input_archive",
+        "usim_population_source_h5",
+    ]
+    assert summary["safe_families_for_phase2"] == expected_safe_families
+
+
+def test_phase2_recovery_root_registration_skips_blocked_h5_family(
+    monkeypatch, tmp_path
+):
+    local_root = tmp_path / "local" / "run"
+    archive_root = tmp_path / "archive" / "run"
+    monkeypatch.setenv("PILATES_ENABLE_ARCHIVE_COPY", "1")
+    monkeypatch.setenv("PILATES_LOCAL_RUN_DIR", str(local_root))
+    monkeypatch.setenv("PILATES_ARCHIVE_RUN_DIR", str(archive_root))
+
+    registration_calls = []
+    tracker = SimpleNamespace(
+        register_run_output_recovery_copies=lambda *args, **kwargs: (
+            registration_calls.append((args, kwargs))
+        )
+    )
+    monkeypatch.setattr(ch.cr, "current_tracker", lambda: tracker)
+    monkeypatch.setattr(ch.cr, "current_run", lambda: SimpleNamespace(id="run-123"))
+    monkeypatch.setattr(ch.cr, "current_run_id", lambda: "run-123")
+    monkeypatch.setattr(ch, "_find_current_run_output_artifact", lambda **_kwargs: None)
+
+    source = local_root / "urbansim" / "data" / "model_data_2030.h5"
+    _write_file(source, "h5")
+    consist_audit.emit_artifact_lifecycle_audit_event(
+        event_type="artifact_logged",
+        key="usim_datastore_h5",
+        path=str(source),
+        artifact_family="usim_datastore_h5",
+        source_role="usim_datastore_h5",
+        snapshot_role="usim_datastore_h5",
+        snapshot_reason="post_merge_handoff",
+        storage_event="merged_h5_output",
+        year=2030,
+        h5_container=True,
+        container_recovery_unit="parent_file",
+        child_recovery_policy="descriptive_only",
+    )
+    assert ch.archive_copy_now(key="usim_datastore_h5", path=str(source))
+
+    assert registration_calls == []
+    summary = _lifecycle_summary(local_root)
+    assert summary["local_to_scratch_recovery_roots_written"] == 0
+    assert "usim_datastore_h5" not in summary["safe_families_for_phase2"]
+
+
+def test_phase2_recovery_root_registration_prefers_artifact_hash_when_full_hashing(
+    monkeypatch, tmp_path
+):
+    local_root = tmp_path / "local" / "run"
+    archive_root = tmp_path / "archive" / "run"
+    monkeypatch.setenv("PILATES_ENABLE_ARCHIVE_COPY", "1")
+    monkeypatch.setenv("PILATES_LOCAL_RUN_DIR", str(local_root))
+    monkeypatch.setenv("PILATES_ARCHIVE_RUN_DIR", str(archive_root))
+
+    registration_calls = []
+    tracker = SimpleNamespace(
+        identity=SimpleNamespace(hashing_strategy="full"),
+        register_run_output_recovery_copies=lambda run_id, recovery_root, **kwargs: (
+            registration_calls.append((run_id, recovery_root, kwargs))
+            or SimpleNamespace(
+                registered={"usim_population_source_h5": object()},
+                blocked={},
+                summary="registered=1",
+            )
+        ),
+    )
+    monkeypatch.setattr(ch.cr, "current_tracker", lambda: tracker)
+    monkeypatch.setattr(ch.cr, "current_run", lambda: SimpleNamespace(id="run-123"))
+    monkeypatch.setattr(ch.cr, "current_run_id", lambda: "run-123")
+
+    source = local_root / "urbansim" / "data" / "model_data_2030.h5"
+    _write_file(source, "h5")
+    artifact = SimpleNamespace(
+        key="usim_population_source_h5",
+        hash="artifact-hash-123",
+        container_uri=str(source),
+    )
+    monkeypatch.setattr(
+        ch,
+        "_find_current_run_output_artifact",
+        lambda *, key, path: artifact,
+    )
+    monkeypatch.setattr(
+        ch.recovery_root_adoption,
+        "_sha256_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("sha called")),
+    )
+    consist_audit.emit_artifact_lifecycle_audit_event(
+        event_type="artifact_logged",
+        key="usim_population_source_h5",
+        path=str(source),
+        artifact_family="usim_population_source_h5",
+        source_role="usim_population_source_h5",
+        snapshot_role="usim_population_source_h5",
+        snapshot_reason="post_merge_handoff",
+        storage_event="merged_h5_output",
+        year=2030,
+        h5_container=True,
+        container_recovery_unit="parent_file",
+        child_recovery_policy="descriptive_only",
+    )
+    assert ch.archive_copy_now(key="usim_population_source_h5", path=str(source))
+
+    assert registration_calls == [
+        (
+            "run-123",
+            str(archive_root),
+            {
+                "append": True,
+                "content_hashes": {"usim_population_source_h5": "artifact-hash-123"},
+                "verify": True,
+            },
+        )
+    ]
 
 
 def test_artifact_lifecycle_summary_keeps_h5_child_tables_ineligible(

--- a/tests/test_atlas_postprocess_logging.py
+++ b/tests/test_atlas_postprocess_logging.py
@@ -5,7 +5,10 @@ import pytest
 
 from pilates.atlas import postprocessor as atlas_postprocessor
 from pilates.atlas.outputs import AtlasPostprocessOutputs, AtlasRunOutputs
-from pilates.workflows.artifact_keys import USIM_POPULATION_SOURCE_H5
+from pilates.workflows.artifact_keys import (
+    ATLAS_VEHICLES2_OUTPUT,
+    USIM_POPULATION_SOURCE_H5,
+)
 from pilates.workflows import steps
 from pilates.workflows.steps import urbansim_atlas as steps_urbansim_atlas
 
@@ -30,11 +33,13 @@ def test_atlas_postprocess_logs_only_canonical_usim_h5_output(monkeypatch, tmp_p
 
     output_logger = captured["output_logger"]
     output_only_keys = []
+    output_only_meta = []
     set_output_keys = []
     publish_meta = []
 
     def _log_output_only(*, key, path, description, **meta):
         output_only_keys.append(key)
+        output_only_meta.append(meta)
 
     def _log_and_set_output(*, key, path, description, coupler, **meta):
         set_output_keys.append(key)
@@ -56,7 +61,7 @@ def test_atlas_postprocess_logs_only_canonical_usim_h5_output(monkeypatch, tmp_p
         usim_datastore_h5=h5_path,
         processed_outputs={
             "usim_h5_updated": h5_path,
-            "atlas_vehicles2_output": vehicles2_path,
+            ATLAS_VEHICLES2_OUTPUT: vehicles2_path,
         },
     )
 
@@ -68,7 +73,15 @@ def test_atlas_postprocess_logs_only_canonical_usim_h5_output(monkeypatch, tmp_p
         holder=SimpleNamespace(),
     )
 
-    assert output_only_keys == ["atlas_vehicles2_output"]
+    assert output_only_keys == [ATLAS_VEHICLES2_OUTPUT]
+    assert output_only_meta[0]["facet"] == {
+        "artifact_family": ATLAS_VEHICLES2_OUTPUT,
+        "source_role": ATLAS_VEHICLES2_OUTPUT,
+        "year": 2023,
+        "iteration": None,
+    }
+    assert output_only_meta[0]["facet_schema_version"] == "v1"
+    assert output_only_meta[0]["facet_index"] is True
     assert set_output_keys == [USIM_POPULATION_SOURCE_H5]
     assert len(publish_meta) == 1
     assert publish_meta[0]["child_selection"] == "include_only"

--- a/tests/test_atlas_postprocess_logging.py
+++ b/tests/test_atlas_postprocess_logging.py
@@ -79,6 +79,60 @@ def test_atlas_postprocess_logs_only_canonical_usim_h5_output(monkeypatch, tmp_p
     } == {"/2023/households": "atlas_postprocess_usim_households_table_updated"}
 
 
+def test_atlas_postprocess_aliases_root_population_tables_before_publish(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+
+    def _fake_build_standard_step(*, spec, **_kwargs):
+        captured["output_logger"] = spec.output_logger
+        return lambda *args, **inner_kwargs: None
+
+    monkeypatch.setattr(
+        steps_urbansim_atlas,
+        "build_standard_step",
+        _fake_build_standard_step,
+    )
+
+    steps.make_atlas_postprocess_step(
+        coupler=SimpleNamespace(),
+        outputs_holder=SimpleNamespace(),
+    )
+
+    output_calls = []
+    monkeypatch.setattr(steps_urbansim_atlas, "log_output_only", lambda **kwargs: None)
+    monkeypatch.setattr(
+        steps_urbansim_atlas,
+        "log_and_set_output",
+        lambda **kwargs: output_calls.append(kwargs),
+    )
+
+    h5_path = tmp_path / "model_data_2021.h5"
+    with pd.HDFStore(h5_path, mode="w") as store:
+        for table_name in ("households", "persons", "jobs", "blocks"):
+            store.put(f"/{table_name}", pd.DataFrame({"value": [1]}))
+
+    captured["output_logger"](
+        AtlasPostprocessOutputs(
+            atlas_output_dir=tmp_path,
+            usim_datastore_h5=h5_path,
+            processed_outputs={"usim_h5_updated": h5_path},
+        ),
+        settings=SimpleNamespace(),
+        state=SimpleNamespace(forecast_year=2021, is_start_year=lambda: False),
+        workspace=SimpleNamespace(),
+        holder=SimpleNamespace(),
+    )
+
+    assert output_calls[0]["h5_tables_used"] == ["/2021/households"]
+    with pd.HDFStore(h5_path, mode="r") as store:
+        assert "/2021/households" in store
+        assert "/2021/persons" in store
+        assert "/2021/jobs" in store
+        assert "/2021/blocks" in store
+
+
 def test_atlas_postprocess_logs_usim_h5_as_input(monkeypatch, tmp_path):
     captured = {}
 

--- a/tests/test_beam_preprocessor_exchange_folder.py
+++ b/tests/test_beam_preprocessor_exchange_folder.py
@@ -536,6 +536,14 @@ def test_beam_preprocess_stages_archive_exact_vehicle_source_with_metadata(
     assert metadata["forecast_year"] == 2018
     assert metadata["source_resolution_mode"] == "exact_forecast_year"
     assert metadata["source_storage_location"] == "archive"
+    assert metadata["filtered_to_staged_households"] is True
+    assert metadata["staged_household_filter_input_vehicle_rows"] == 2
+    assert metadata["staged_household_filter_removed_vehicle_rows"] == 1
+    assert metadata["staged_household_filter_remaining_vehicle_rows"] == 1
+    assert metadata["staged_household_filter_household_rows"] == 1
+    assert metadata["staged_household_filter_vehicles_path"] == str(
+        scenario_dir / "vehicles.parquet"
+    )
 
 
 def test_beam_preprocessor_expected_inputs_use_archive_atlas_vehicle_candidate(

--- a/tests/test_beam_preprocessor_exchange_folder.py
+++ b/tests/test_beam_preprocessor_exchange_folder.py
@@ -390,6 +390,50 @@ def test_beam_preprocess_prefers_explicit_atlas_vehicle_input_over_workspace_fal
     )
 
 
+def test_beam_preprocessor_expected_inputs_use_archive_atlas_vehicle_candidate(
+    tmp_path,
+):
+    local_root = tmp_path / "local-run"
+    archive_root = tmp_path / "archive-run"
+    atlas_rel = Path("atlas") / "atlas_output"
+    archive_vehicles = archive_root / atlas_rel / "vehicles2_2030.csv"
+    archive_vehicles.parent.mkdir(parents=True)
+    archive_vehicles.write_text("archive forecast vehicles", encoding="utf-8")
+
+    settings = SimpleNamespace(
+        run=SimpleNamespace(
+            region="sfbay",
+            models=SimpleNamespace(traffic_assignment="beam"),
+        ),
+        runtime=SimpleNamespace(
+            flags=SimpleNamespace(
+                activity_demand_enabled=True,
+                vehicle_ownership_model_enabled=True,
+            )
+        ),
+        beam=SimpleNamespace(
+            scenario_folder="urbansim",
+            config="sfbay-pilates-base-omx.conf",
+        ),
+        activitysim=SimpleNamespace(file_format="parquet"),
+    )
+    state = SimpleNamespace(
+        current_inner_iter=0,
+        forecast_year=2030,
+        year=2024,
+        run_info_path=str(archive_root / "run_state.yaml"),
+    )
+    workspace = MagicMock()
+    workspace.full_path = str(local_root)
+    workspace.get_beam_mutable_data_dir.return_value = str(local_root / "beam" / "input")
+    workspace.get_asim_output_dir.return_value = str(local_root / "activitysim" / "output")
+    workspace.get_atlas_output_dir.return_value = str(local_root / atlas_rel)
+
+    expected = BeamPreprocessor.expected_inputs(settings, state, workspace)
+
+    assert expected[ATLAS_VEHICLES2_OUTPUT] == str(archive_vehicles)
+
+
 def test_normalize_beam_vehicle_columns_synthesizes_global_ids_for_household_local_ids():
     normalized = _normalize_beam_vehicle_columns(
         pd.DataFrame(

--- a/tests/test_beam_preprocessor_exchange_folder.py
+++ b/tests/test_beam_preprocessor_exchange_folder.py
@@ -286,8 +286,9 @@ def test_beam_preprocess_fails_when_vehicle_households_are_missing_from_staged_h
             ]
         )
 
-    def _fake_copy_vehicles(_workspace, source_path=None):
+    def _fake_copy_vehicles(_workspace, source_path=None, require_exact_year=False):
         _ = source_path
+        _ = require_exact_year
         pd.DataFrame(
             {
                 "vehicleId": [100],
@@ -319,11 +320,11 @@ def test_beam_preprocess_prefers_explicit_atlas_vehicle_input_over_workspace_fal
 
     scenario_dir = tmp_path / "beam" / "input" / "sfbay" / "urbansim"
     scenario_dir.mkdir(parents=True, exist_ok=True)
-    explicit_vehicles = tmp_path / "restored" / "vehicles.csv.gz"
+    explicit_vehicles = tmp_path / "restored" / "vehicles2_2018.csv"
     explicit_vehicles.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(
         {"vehicle_id": [100], "household_id": [1], "vehicleTypeId": ["sedan_gas_2015"]}
-    ).to_csv(explicit_vehicles, index=False, compression="gzip")
+    ).to_csv(explicit_vehicles, index=False)
 
     monkeypatch.setattr(
         preprocessor, "_update_beam_config", lambda *args, **kwargs: None
@@ -362,8 +363,9 @@ def test_beam_preprocess_prefers_explicit_atlas_vehicle_input_over_workspace_fal
 
     captured = {}
 
-    def _fake_copy_vehicles(_workspace, source_path=None):
+    def _fake_copy_vehicles(_workspace, source_path=None, require_exact_year=False):
         captured["source_path"] = source_path
+        captured["require_exact_year"] = require_exact_year
         pd.DataFrame(
             {
                 "vehicleId": [100],
@@ -385,9 +387,149 @@ def test_beam_preprocess_prefers_explicit_atlas_vehicle_input_over_workspace_fal
     )
 
     assert captured["source_path"] == str(explicit_vehicles)
+    assert captured["require_exact_year"] is True
     assert (
         outputs.prepared_inputs["vehicles_beam_in"] == scenario_dir / "vehicles.parquet"
     )
+
+
+def test_beam_preprocess_rejects_stale_restored_vehicle_input_for_activitysim(
+    monkeypatch, tmp_path
+):
+    preprocessor = _make_preprocessor(
+        scenario_folder="urbansim",
+        activity_demand_enabled=True,
+    )
+    preprocessor.settings.vehicle_ownership_model_enabled = True
+    workspace = _make_workspace(tmp_path)
+    workspace.get_atlas_output_dir.return_value = str(
+        tmp_path / "atlas" / "atlas_output"
+    )
+
+    scenario_dir = tmp_path / "beam" / "input" / "sfbay" / "urbansim"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+    stale_vehicles = tmp_path / "restored" / "vehicles.parquet"
+    stale_vehicles.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {"vehicleId": [100], "householdId": [1], "vehicleTypeId": ["sedan_gas_2015"]}
+    ).to_parquet(stale_vehicles, index=False)
+
+    monkeypatch.setattr(
+        preprocessor, "_update_beam_config", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(preprocessor, "_handle_linkstats", lambda *args, **kwargs: None)
+
+    def _fake_copy_plans(_input_records, _workspace):
+        pd.DataFrame({"household_id": [1], "cars": [1]}).to_parquet(
+            scenario_dir / "households.parquet",
+            index=False,
+        )
+        pd.DataFrame({"person_id": [11], "household_id": [1]}).to_parquet(
+            scenario_dir / "persons.parquet",
+            index=False,
+        )
+        pd.DataFrame({"trip_id": [1], "person_id": [11]}).to_parquet(
+            scenario_dir / "plans.parquet",
+            index=False,
+        )
+        return RecordStore(
+            recordList=[
+                FileRecord(
+                    file_path=str(scenario_dir / "households.parquet"),
+                    short_name=BEAM_HOUSEHOLDS_IN,
+                ),
+                FileRecord(
+                    file_path=str(scenario_dir / "persons.parquet"),
+                    short_name=BEAM_PERSONS_IN,
+                ),
+                FileRecord(
+                    file_path=str(scenario_dir / "plans.parquet"),
+                    short_name=BEAM_PLANS_IN,
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(preprocessor, "_copy_plans_from_asim", _fake_copy_plans)
+
+    with pytest.raises(FileNotFoundError, match="exact forecast-year ATLAS vehicles2"):
+        preprocessor.preprocess(
+            workspace,
+            beam_preprocess_inputs={"vehicles_beam_in": str(stale_vehicles)},
+        )
+
+
+def test_beam_preprocess_stages_archive_exact_vehicle_source_with_metadata(
+    monkeypatch, tmp_path
+):
+    preprocessor = _make_preprocessor(
+        scenario_folder="urbansim",
+        activity_demand_enabled=True,
+    )
+    preprocessor.settings.vehicle_ownership_model_enabled = True
+    preprocessor.state.run_info_path = str(tmp_path / "archive-run" / "run_state.yaml")
+    workspace = _make_workspace(tmp_path / "local-run")
+    local_root = Path(workspace.full_path)
+    archive_root = Path(preprocessor.state.run_info_path).parent
+    atlas_rel = Path("atlas") / "atlas_output"
+    archive_vehicles = archive_root / atlas_rel / "vehicles2_2018.csv"
+    archive_vehicles.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {"vehicle_id": [100], "household_id": [1], "vehicleTypeId": ["sedan_gas_2015"]}
+    ).to_csv(archive_vehicles, index=False)
+    workspace.get_atlas_output_dir.return_value = str(local_root / atlas_rel)
+
+    scenario_dir = local_root / "beam" / "input" / "sfbay" / "urbansim"
+    scenario_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        preprocessor, "_update_beam_config", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(preprocessor, "_handle_linkstats", lambda *args, **kwargs: None)
+
+    def _fake_copy_plans(_input_records, _workspace):
+        pd.DataFrame({"household_id": [1], "cars": [1]}).to_parquet(
+            scenario_dir / "households.parquet",
+            index=False,
+        )
+        pd.DataFrame({"person_id": [11], "household_id": [1]}).to_parquet(
+            scenario_dir / "persons.parquet",
+            index=False,
+        )
+        pd.DataFrame({"trip_id": [1], "person_id": [11]}).to_parquet(
+            scenario_dir / "plans.parquet",
+            index=False,
+        )
+        return RecordStore(
+            recordList=[
+                FileRecord(
+                    file_path=str(scenario_dir / "households.parquet"),
+                    short_name=BEAM_HOUSEHOLDS_IN,
+                ),
+                FileRecord(
+                    file_path=str(scenario_dir / "persons.parquet"),
+                    short_name=BEAM_PERSONS_IN,
+                ),
+                FileRecord(
+                    file_path=str(scenario_dir / "plans.parquet"),
+                    short_name=BEAM_PLANS_IN,
+                ),
+            ]
+        )
+
+    monkeypatch.setattr(preprocessor, "_copy_plans_from_asim", _fake_copy_plans)
+
+    outputs = preprocessor.preprocess(workspace)
+
+    assert (
+        outputs.prepared_inputs["vehicles_beam_in"] == scenario_dir / "vehicles.parquet"
+    )
+    metadata = outputs.prepared_input_metadata["vehicles_beam_in"]
+    assert metadata["source_semantic_key"] == ATLAS_VEHICLES2_OUTPUT
+    assert metadata["source_path"] == str(archive_vehicles)
+    assert metadata["source_year"] == 2018
+    assert metadata["forecast_year"] == 2018
+    assert metadata["source_resolution_mode"] == "exact_forecast_year"
+    assert metadata["source_storage_location"] == "archive"
 
 
 def test_beam_preprocessor_expected_inputs_use_archive_atlas_vehicle_candidate(
@@ -425,8 +567,12 @@ def test_beam_preprocessor_expected_inputs_use_archive_atlas_vehicle_candidate(
     )
     workspace = MagicMock()
     workspace.full_path = str(local_root)
-    workspace.get_beam_mutable_data_dir.return_value = str(local_root / "beam" / "input")
-    workspace.get_asim_output_dir.return_value = str(local_root / "activitysim" / "output")
+    workspace.get_beam_mutable_data_dir.return_value = str(
+        local_root / "beam" / "input"
+    )
+    workspace.get_asim_output_dir.return_value = str(
+        local_root / "activitysim" / "output"
+    )
     workspace.get_atlas_output_dir.return_value = str(local_root / atlas_rel)
 
     expected = BeamPreprocessor.expected_inputs(settings, state, workspace)

--- a/tests/test_beam_preprocessor_exchange_folder.py
+++ b/tests/test_beam_preprocessor_exchange_folder.py
@@ -238,7 +238,7 @@ def test_beam_preprocess_does_not_fallback_to_defaults_when_activitysim_enabled(
         preprocessor.preprocess(workspace)
 
 
-def test_beam_preprocess_fails_when_vehicle_households_are_missing_from_staged_households(
+def test_beam_preprocess_fails_when_staged_households_have_vehicle_shortfall(
     monkeypatch, tmp_path
 ):
     preprocessor = _make_preprocessor(
@@ -304,7 +304,7 @@ def test_beam_preprocess_fails_when_vehicle_households_are_missing_from_staged_h
     monkeypatch.setattr(preprocessor, "_copy_plans_from_asim", _fake_copy_plans)
     monkeypatch.setattr(preprocessor, "_copy_vehicles_from_atlas", _fake_copy_vehicles)
 
-    with pytest.raises(ValueError, match="reference households that are absent"):
+    with pytest.raises(ValueError, match="require more cars"):
         preprocessor.preprocess(workspace)
 
 
@@ -474,7 +474,11 @@ def test_beam_preprocess_stages_archive_exact_vehicle_source_with_metadata(
     archive_vehicles = archive_root / atlas_rel / "vehicles2_2018.csv"
     archive_vehicles.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(
-        {"vehicle_id": [100], "household_id": [1], "vehicleTypeId": ["sedan_gas_2015"]}
+        {
+            "vehicle_id": [100, 200],
+            "household_id": [1, 999],
+            "vehicleTypeId": ["sedan_gas_2015", "sedan_gas_2015"],
+        }
     ).to_csv(archive_vehicles, index=False)
     workspace.get_atlas_output_dir.return_value = str(local_root / atlas_rel)
 
@@ -523,6 +527,8 @@ def test_beam_preprocess_stages_archive_exact_vehicle_source_with_metadata(
     assert (
         outputs.prepared_inputs["vehicles_beam_in"] == scenario_dir / "vehicles.parquet"
     )
+    staged_vehicles = pd.read_parquet(scenario_dir / "vehicles.parquet")
+    assert staged_vehicles["householdId"].tolist() == [1]
     metadata = outputs.prepared_input_metadata["vehicles_beam_in"]
     assert metadata["source_semantic_key"] == ATLAS_VEHICLES2_OUTPUT
     assert metadata["source_path"] == str(archive_vehicles)

--- a/tests/test_beam_run_logging.py
+++ b/tests/test_beam_run_logging.py
@@ -90,6 +90,8 @@ def test_beam_preprocess_logs_vehicle_source_provenance(monkeypatch, tmp_path):
                 "forecast_year": 2030,
                 "source_resolution_mode": "exact_forecast_year",
                 "source_storage_location": "archive",
+                "filtered_to_staged_households": True,
+                "staged_household_filter_removed_vehicle_rows": 12,
             }
         },
     )
@@ -113,6 +115,8 @@ def test_beam_preprocess_logs_vehicle_source_provenance(monkeypatch, tmp_path):
         "source_year": 2030,
         "source_resolution_mode": "exact_forecast_year",
         "source_storage_location": "archive",
+        "filtered_to_staged_households": True,
+        "staged_household_filter_removed_vehicle_rows": 12,
     }
     assert meta["facet_schema_version"] == "v1"
     assert meta["facet_index"] is True

--- a/tests/test_beam_run_logging.py
+++ b/tests/test_beam_run_logging.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("openmatrix")
 
 from pilates.beam.outputs import BeamPreprocessOutputs, BeamRunOutputs
+from pilates.workflows.artifact_keys import ATLAS_VEHICLES2_OUTPUT
 from pilates.workflows.steps import beam as steps_beam
 
 
@@ -45,6 +46,77 @@ def test_beam_preprocess_fails_early_when_config_file_missing(monkeypatch, tmp_p
         assert "seattle-pilates.conf" in str(exc)
     else:
         raise AssertionError("Expected FileNotFoundError for missing BEAM config")
+
+
+def test_beam_preprocess_logs_vehicle_source_provenance(monkeypatch, tmp_path):
+    captured = {}
+
+    def _fake_build_standard_step(*, spec, **_kwargs):
+        captured["output_logger"] = spec.output_logger
+        return lambda *args, **inner_kwargs: None
+
+    monkeypatch.setattr(
+        steps_beam,
+        "build_standard_step",
+        _fake_build_standard_step,
+    )
+
+    steps_beam.make_beam_preprocess_step(
+        coupler=SimpleNamespace(),
+        outputs_holder=SimpleNamespace(),
+    )
+
+    output_logger = captured["output_logger"]
+    calls = []
+    monkeypatch.setattr(
+        steps_beam,
+        "log_and_set_output",
+        lambda *, key, path, description, coupler, **meta: calls.append(
+            (key, path, description, meta)
+        ),
+    )
+
+    vehicles_path = tmp_path / "vehicles.parquet"
+    vehicles_path.write_text("vehicles", encoding="utf-8")
+    source_path = tmp_path / "atlas" / "vehicles2_2030.csv"
+    outputs = BeamPreprocessOutputs(
+        beam_mutable_data_dir=tmp_path / "beam" / "input",
+        prepared_inputs={"vehicles_beam_in": vehicles_path},
+        prepared_input_metadata={
+            "vehicles_beam_in": {
+                "source_semantic_key": ATLAS_VEHICLES2_OUTPUT,
+                "source_path": str(source_path),
+                "source_year": 2030,
+                "forecast_year": 2030,
+                "source_resolution_mode": "exact_forecast_year",
+                "source_storage_location": "archive",
+            }
+        },
+    )
+
+    output_logger(
+        outputs,
+        settings=SimpleNamespace(),
+        state=SimpleNamespace(year=2030, forecast_year=2030, iteration=2),
+        workspace=SimpleNamespace(),
+        holder=SimpleNamespace(),
+    )
+
+    assert calls[0][0] == "vehicles_beam_in"
+    meta = calls[0][3]
+    assert meta["facet"] == {
+        "artifact_family": "beam_preprocess_input",
+        "source_role": "vehicles_beam_in",
+        "derived_from": ATLAS_VEHICLES2_OUTPUT,
+        "year": 2030,
+        "iteration": 2,
+        "source_year": 2030,
+        "source_resolution_mode": "exact_forecast_year",
+        "source_storage_location": "archive",
+    }
+    assert meta["facet_schema_version"] == "v1"
+    assert meta["facet_index"] is True
+    assert meta["source_path"] == str(source_path)
 
 
 def test_beam_run_logs_config_file_input(monkeypatch, tmp_path):

--- a/tests/test_cache_hit_recovery.py
+++ b/tests/test_cache_hit_recovery.py
@@ -293,8 +293,15 @@ def test_recover_beam_preprocess_outputs(tmp_path):
     plans_path = beam_dir / "seattle" / "urbansim" / "plans.parquet"
     households_path = beam_dir / "seattle" / "urbansim" / "households.parquet"
     persons_path = beam_dir / "seattle" / "urbansim" / "persons.parquet"
+    vehicles_path = beam_dir / "seattle" / "urbansim" / "vehicles.parquet"
     linkstats_path = beam_dir / "seattle" / "r5" / "init.linkstats.csv.gz"
-    for path in (plans_path, households_path, persons_path, linkstats_path):
+    for path in (
+        plans_path,
+        households_path,
+        persons_path,
+        vehicles_path,
+        linkstats_path,
+    ):
         _write_file(path)
 
     coupler = DummyCoupler()
@@ -312,13 +319,31 @@ def test_recover_beam_preprocess_outputs(tmp_path):
             BEAM_PLANS_IN: str(plans_path),
             BEAM_HOUSEHOLDS_IN: str(households_path),
             BEAM_PERSONS_IN: str(persons_path),
+            "vehicles_beam_in": str(vehicles_path),
             LINKSTATS_WARMSTART: str(linkstats_path),
+        },
+        cached_outputs={
+            "prepared_input_metadata": {
+                "vehicles_beam_in": {
+                    "source_semantic_key": "atlas_vehicles2_output",
+                    "source_path": "/archive/atlas/vehicles2_2018.csv",
+                    "source_year": 2018,
+                    "forecast_year": 2018,
+                    "source_resolution_mode": "exact_forecast_year",
+                }
+            }
         },
     )
 
     assert outputs is not None
     assert holder.beam_preprocess is not None
     assert holder.beam_preprocess.prepared_inputs[BEAM_PLANS_IN] == plans_path
+    assert (
+        holder.beam_preprocess.prepared_input_metadata["vehicles_beam_in"][
+            "source_resolution_mode"
+        ]
+        == "exact_forecast_year"
+    )
     assert coupler.get(BEAM_PLANS_IN) is not None
     assert coupler.get(BEAM_HOUSEHOLDS_IN) is not None
     assert coupler.get(BEAM_PERSONS_IN) is not None

--- a/tests/test_cache_hit_recovery.py
+++ b/tests/test_cache_hit_recovery.py
@@ -330,6 +330,8 @@ def test_recover_beam_preprocess_outputs(tmp_path):
                     "source_year": 2018,
                     "forecast_year": 2018,
                     "source_resolution_mode": "exact_forecast_year",
+                    "filtered_to_staged_households": True,
+                    "staged_household_filter_removed_vehicle_rows": 148861,
                 }
             }
         },
@@ -343,6 +345,12 @@ def test_recover_beam_preprocess_outputs(tmp_path):
             "source_resolution_mode"
         ]
         == "exact_forecast_year"
+    )
+    assert (
+        holder.beam_preprocess.prepared_input_metadata["vehicles_beam_in"][
+            "staged_household_filter_removed_vehicle_rows"
+        ]
+        == 148861
     )
     assert coupler.get(BEAM_PLANS_IN) is not None
     assert coupler.get(BEAM_HOUSEHOLDS_IN) is not None

--- a/tests/test_golden_stub_workflow.py
+++ b/tests/test_golden_stub_workflow.py
@@ -427,6 +427,12 @@ def golden_stub_env(tmp_path, monkeypatch):
     beam_config_path = beam_dir / settings.run.region / settings.beam.config
     _write_file(beam_config_path)
 
+    forecast_vehicles2_path = atlas_output_dir / f"vehicles2_{state.forecast_year}.csv"
+    forecast_vehicles2_path.write_text(
+        "vehicleId,householdId,vehicleTypeId\n1,10,sedan\n",
+        encoding="utf-8",
+    )
+
     region_id = settings.urbansim.region_mappings["region_to_region_id"][
         settings.run.region
     ]

--- a/tests/test_golden_workflow_contracts.py
+++ b/tests/test_golden_workflow_contracts.py
@@ -199,7 +199,7 @@ def test_golden_workflow_preserves_current_stage_surfaces_on_scenario_outputs(
         Path(final_usim_datastore).resolve()
         == Path(scenario_outputs[USIM_DATASTORE_H5].path).resolve()
     )
-    assert Path(final_usim_datastore).resolve() != Path(base_usim_datastore).resolve()
+    assert Path(final_usim_datastore).resolve() == Path(base_usim_datastore).resolve()
 
     assert EXPECTED_ASIM_ARCHIVE_OUTPUT_KEYS <= scenario_output_keys
     assert {ZARR_SKIMS, LINKSTATS, BEAM_PLANS_OUT} <= scenario_output_keys

--- a/tests/test_promote_run_archive.py
+++ b/tests/test_promote_run_archive.py
@@ -444,13 +444,7 @@ def test_promote_run_to_recovery_roots_skips_activitysim_final_pipeline_tree(
     archived_output_file.parent.mkdir(parents=True, exist_ok=True)
     archived_output_file.write_text("archived-output", encoding="utf-8")
 
-    numba_cache_file = (
-        run_dir
-        / "shared_cache"
-        / "numba"
-        / "flow_example"
-        / "cache.bin"
-    )
+    numba_cache_file = run_dir / "shared_cache" / "numba" / "flow_example" / "cache.bin"
     numba_cache_file.parent.mkdir(parents=True, exist_ok=True)
     numba_cache_file.write_text("numba-cache", encoding="utf-8")
 
@@ -466,11 +460,7 @@ def test_promote_run_to_recovery_roots_skips_activitysim_final_pipeline_tree(
     snapshot_history_file.write_text("snapshot-history", encoding="utf-8")
 
     snapshot_latest_file = (
-        run_dir
-        / ".consist"
-        / "snapshots"
-        / "latest"
-        / "provenance.duckdb"
+        run_dir / ".consist" / "snapshots" / "latest" / "provenance.duckdb"
     )
     snapshot_latest_file.parent.mkdir(parents=True, exist_ok=True)
     snapshot_latest_file.write_text("snapshot-latest", encoding="utf-8")
@@ -485,7 +475,13 @@ def test_promote_run_to_recovery_roots_skips_activitysim_final_pipeline_tree(
 
         assert result.success is True
         assert archived_output_file.exists()
-        assert (promoted / "activitysim" / "output" / "year-2021-iteration-0" / "persons.parquet").exists()
+        assert (
+            promoted
+            / "activitysim"
+            / "output"
+            / "year-2021-iteration-0"
+            / "persons.parquet"
+        ).exists()
         assert not (promoted / "activitysim" / "output" / "final_pipeline").exists()
         assert not (promoted / "shared_cache" / "numba").exists()
         assert not (

--- a/tests/test_promote_run_archive.py
+++ b/tests/test_promote_run_archive.py
@@ -327,6 +327,94 @@ def test_promote_run_to_recovery_root_scopes_seeded_db_merge(tmp_path):
         tracker.db.engine.dispose()
 
 
+def test_promote_run_to_recovery_roots_skips_activitysim_final_pipeline_tree(
+    tmp_path,
+):
+    consist = pytest.importorskip("consist")
+    recovery_root = tmp_path / "nfs"
+    settings = _minimal_config(tmp_path, recovery_roots=[str(recovery_root)])
+    run_dir = Path(settings.run.output_directory) / settings.run.output_run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    tracker, _run_id, _output_path = _seed_run_archive(consist, run_dir)
+    final_pipeline_file = (
+        run_dir
+        / "activitysim"
+        / "output"
+        / "final_pipeline"
+        / "persons"
+        / "final.parquet"
+    )
+    final_pipeline_file.parent.mkdir(parents=True, exist_ok=True)
+    final_pipeline_file.write_text("final-pipeline", encoding="utf-8")
+
+    archived_output_file = (
+        run_dir / "activitysim" / "output" / "year-2021-iteration-0" / "persons.parquet"
+    )
+    archived_output_file.parent.mkdir(parents=True, exist_ok=True)
+    archived_output_file.write_text("archived-output", encoding="utf-8")
+
+    numba_cache_file = (
+        run_dir
+        / "shared_cache"
+        / "numba"
+        / "flow_example"
+        / "cache.bin"
+    )
+    numba_cache_file.parent.mkdir(parents=True, exist_ok=True)
+    numba_cache_file.write_text("numba-cache", encoding="utf-8")
+
+    snapshot_history_file = (
+        run_dir
+        / ".consist"
+        / "snapshots"
+        / "history"
+        / "20260605-000000_foo"
+        / "provenance.duckdb"
+    )
+    snapshot_history_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_history_file.write_text("snapshot-history", encoding="utf-8")
+
+    snapshot_latest_file = (
+        run_dir
+        / ".consist"
+        / "snapshots"
+        / "latest"
+        / "provenance.duckdb"
+    )
+    snapshot_latest_file.parent.mkdir(parents=True, exist_ok=True)
+    snapshot_latest_file.write_text("snapshot-latest", encoding="utf-8")
+
+    promoted = recovery_root / run_dir.name
+    try:
+        result = promote_run_to_recovery_roots(
+            settings,
+            archive_run_dir=str(run_dir),
+            tracker=tracker,
+        )
+
+        assert result.success is True
+        assert archived_output_file.exists()
+        assert (promoted / "activitysim" / "output" / "year-2021-iteration-0" / "persons.parquet").exists()
+        assert not (promoted / "activitysim" / "output" / "final_pipeline").exists()
+        assert not (promoted / "shared_cache" / "numba").exists()
+        assert not (
+            promoted
+            / ".consist"
+            / "snapshots"
+            / "history"
+            / "20260605-000000_foo"
+            / "provenance.duckdb"
+        ).exists()
+        assert (promoted / ".consist" / "snapshots" / "latest").exists()
+        assert final_pipeline_file.exists()
+        assert numba_cache_file.exists()
+        assert snapshot_history_file.exists()
+        assert snapshot_latest_file.exists()
+    finally:
+        tracker.db.engine.dispose()
+
+
 def test_promote_run_to_recovery_roots_uses_snapshot_latest_archive_db_when_direct_copy_missing(
     tmp_path,
 ):
@@ -396,6 +484,81 @@ def test_promote_run_to_recovery_roots_uses_snapshot_latest_archive_db_when_dire
         assert (
             promoted / ".consist" / "snapshots" / "latest" / "provenance.duckdb"
         ).exists()
+    finally:
+        tracker.db.engine.dispose()
+
+
+def test_promote_run_to_recovery_roots_merge_only_reuses_existing_copy(
+    tmp_path, monkeypatch
+):
+    consist = pytest.importorskip("consist")
+    recovery_root = tmp_path / "nfs"
+    settings = _minimal_config(tmp_path, recovery_roots=[str(recovery_root)])
+
+    main_run_dir = tmp_path / "main-catalog"
+    main_tracker = _make_tracker(consist, main_run_dir)
+    main_db_path = main_run_dir / ".consist" / "provenance.duckdb"
+
+    try:
+        _seed_output_run(
+            main_tracker,
+            main_run_dir,
+            run_name="historical_root",
+            model="history",
+            key="old_output",
+            relative_path="outputs/old-result.txt",
+            content="old-result-data",
+        )
+    finally:
+        main_tracker.db.engine.dispose()
+
+    run_dir = Path(settings.run.output_directory) / settings.run.output_run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    tracker = _make_tracker(consist, run_dir)
+    _seed_output_run(
+        tracker,
+        run_dir,
+        run_name="new_root",
+        model="demo",
+        key="new_output",
+        relative_path="outputs/new-result.txt",
+        content="new-result-data",
+    )
+
+    promoted = recovery_root / run_dir.name
+
+    try:
+        first = promote_run_to_recovery_roots(
+            settings,
+            archive_run_dir=str(run_dir),
+            tracker=tracker,
+            merge_main_db=str(main_db_path),
+            merge_dry_run=True,
+        )
+        assert first.success is True
+        assert promoted.exists()
+
+        def fail_copy(*_args, **_kwargs):
+            raise AssertionError("copy_run_tree should not run during merge-only")
+
+        monkeypatch.setattr(
+            "pilates.runtime.promote_run_archive._copy_run_tree",
+            fail_copy,
+        )
+
+        second = promote_run_to_recovery_roots(
+            settings,
+            archive_run_dir=str(run_dir),
+            tracker=tracker,
+            merge_main_db=str(main_db_path),
+            merge_only=True,
+        )
+
+        assert second.success is True
+        assert second.roots[0].copy_performed is False
+        assert second.roots[0].verified is True
+        assert promoted.exists()
+        assert (promoted / ".consist" / "recovery_promotion.json").exists()
     finally:
         tracker.db.engine.dispose()
 

--- a/tests/test_promote_run_archive.py
+++ b/tests/test_promote_run_archive.py
@@ -185,6 +185,60 @@ def test_register_verified_recovery_copies_uses_consist_registration_api(tmp_pat
     ]
 
 
+def test_register_verified_recovery_copies_can_skip_hash_verification(
+    tmp_path, monkeypatch
+):
+    source_run_dir = tmp_path / "source-run"
+    recovery_run_dir = tmp_path / "recovery-run"
+    calls = []
+
+    class FakeTracker:
+        def get_run_outputs(self, run_id):
+            assert run_id == "run-1"
+            return {
+                "demo_output": SimpleNamespace(
+                    container_uri="workspace://outputs/result.txt"
+                )
+            }
+
+        def register_run_output_recovery_copies(self, run_id, recovery_root, **kwargs):
+            calls.append((run_id, recovery_root, kwargs))
+            return SimpleNamespace(
+                registered={"demo_output": object()},
+                blocked={},
+                summary="registered=1",
+            )
+
+    def fail_hash(*_args, **_kwargs):
+        raise AssertionError("source hashing should be skipped when verify=False")
+
+    monkeypatch.setattr(
+        "pilates.runtime.promote_run_archive._run_output_content_hashes",
+        fail_hash,
+    )
+
+    registered = _register_verified_run_output_recovery_copies(
+        FakeTracker(),
+        source_run_dir=source_run_dir,
+        recovery_run_dir=recovery_run_dir,
+        run_ids=["run-1"],
+        verify=False,
+    )
+
+    assert registered == 1
+    assert calls == [
+        (
+            "run-1",
+            str(recovery_run_dir),
+            {
+                "append": True,
+                "content_hashes": None,
+                "verify": False,
+            },
+        )
+    ]
+
+
 def test_promote_run_to_recovery_root_copies_run_dir_and_updates_recovery_roots(
     tmp_path,
 ):
@@ -241,6 +295,42 @@ def test_promote_run_to_recovery_root_copies_run_dir_and_updates_recovery_roots(
         assert marker["source_run_dir"] == str(run_dir)
         assert marker["roots"][0]["status"] == "promoted"
         assert (promoted / ".consist" / "recovery_promotion.json").exists()
+    finally:
+        tracker.db.engine.dispose()
+
+
+def test_promote_run_to_recovery_roots_can_skip_recovery_copy_verification(
+    tmp_path, monkeypatch
+):
+    consist = pytest.importorskip("consist")
+    recovery_root = tmp_path / "nfs"
+    settings = _minimal_config(tmp_path, recovery_roots=[str(recovery_root)])
+    run_dir = Path(settings.run.output_directory) / settings.run.output_run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    tracker, _run_id, _output_path = _seed_run_archive(consist, run_dir)
+    calls = []
+
+    def fake_register_verified_run_output_recovery_copies(*_args, **kwargs):
+        calls.append(kwargs.get("verify"))
+        return 1
+
+    monkeypatch.setattr(
+        "pilates.runtime.promote_run_archive._register_verified_run_output_recovery_copies",
+        fake_register_verified_run_output_recovery_copies,
+    )
+
+    try:
+        result = promote_run_to_recovery_roots(
+            settings,
+            archive_run_dir=str(run_dir),
+            tracker=tracker,
+            recovery_copy_verify=False,
+        )
+
+        assert result.success is True
+        assert calls == [False]
+        assert result.roots[0].artifact_metadata_updated is True
     finally:
         tracker.db.engine.dispose()
 

--- a/tests/test_promote_run_archive.py
+++ b/tests/test_promote_run_archive.py
@@ -10,6 +10,7 @@ import pytest
 
 from pilates.config import PilatesConfig
 from pilates.runtime.promote_run_archive import (
+    _archive_db_path,
     _register_verified_run_output_recovery_copies,
     promote_run_to_recovery_roots,
 )
@@ -322,6 +323,79 @@ def test_promote_run_to_recovery_root_scopes_seeded_db_merge(tmp_path):
                 assert new_run_id in merged_run_ids
             finally:
                 merged_tracker.db.engine.dispose()
+    finally:
+        tracker.db.engine.dispose()
+
+
+def test_promote_run_to_recovery_roots_uses_snapshot_latest_archive_db_when_direct_copy_missing(
+    tmp_path,
+):
+    consist = pytest.importorskip("consist")
+    recovery_root = tmp_path / "nfs"
+    settings = _minimal_config(tmp_path, recovery_roots=[str(recovery_root)])
+
+    main_run_dir = tmp_path / "main-catalog"
+    main_tracker = _make_tracker(consist, main_run_dir)
+    main_db_path = main_run_dir / ".consist" / "provenance.duckdb"
+
+    try:
+        _seed_output_run(
+            main_tracker,
+            main_run_dir,
+            run_name="historical_root",
+            model="history",
+            key="old_output",
+            relative_path="outputs/old-result.txt",
+            content="old-result-data",
+        )
+    finally:
+        main_tracker.db.engine.dispose()
+
+    run_dir = Path(settings.run.output_directory) / settings.run.output_run_name
+    run_dir.mkdir(parents=True, exist_ok=True)
+    tracker = _make_tracker(consist, run_dir)
+    new_run_id, _new_output_path = _seed_output_run(
+        tracker,
+        run_dir,
+        run_name="new_root",
+        model="demo",
+        key="new_output",
+        relative_path="outputs/new-result.txt",
+        content="new-result-data",
+    )
+
+    source_db = run_dir / ".consist" / "provenance.duckdb"
+    source_wal = Path(f"{source_db}.wal")
+    snapshot_db = run_dir / ".consist" / "snapshots" / "latest" / "provenance.duckdb"
+    snapshot_db.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_db, snapshot_db)
+    if source_wal.exists():
+        shutil.copy2(source_wal, Path(f"{snapshot_db}.wal"))
+
+    tracker.db.engine.dispose()
+    source_db.unlink()
+    source_wal.unlink(missing_ok=True)
+
+    promoted = recovery_root / run_dir.name
+    assert _archive_db_path(settings, archive_run_dir=run_dir) == snapshot_db
+
+    try:
+        result = promote_run_to_recovery_roots(
+            settings,
+            archive_run_dir=str(run_dir),
+            roots=[str(recovery_root)],
+            merge_main_db=str(main_db_path),
+            merge_dry_run=True,
+        )
+
+        assert result.success is True
+        assert result.db_path == str(snapshot_db)
+        assert result.root_run_id == new_run_id
+        assert promoted.exists()
+        assert (promoted / ".consist" / "recovery_promotion.json").exists()
+        assert (
+            promoted / ".consist" / "snapshots" / "latest" / "provenance.duckdb"
+        ).exists()
     finally:
         tracker.db.engine.dispose()
 

--- a/tests/test_restart_equivalence_stubbed.py
+++ b/tests/test_restart_equivalence_stubbed.py
@@ -130,7 +130,7 @@ def _build_test_settings(root: Path, run_name: str) -> Any:
     settings.run.start_year = 2017
     settings.run.end_year = 2019
     settings.run.supply_demand_iters = 2
-    settings.run.travel_model_freq = 1
+    settings.run.travel_model_freq = 2
     settings.run.output_directory = str(root / "outputs")
     settings.land_use_enabled = True
     settings.vehicle_ownership_model_enabled = True
@@ -418,8 +418,11 @@ def _install_model_factory_stubs(monkeypatch, settings: Any) -> None:
                 }
                 if int(state.year) > int(state.start_year):
                     outputs["atlas_grave_csv"] = year_dir / "grave.csv"
-                for path in outputs.values():
-                    _write_csv(path, pd.DataFrame({"id": [1, 2]}))
+                for key, path in outputs.items():
+                    if key == "atlas_households_csv":
+                        _write_csv(path, pd.DataFrame({"household_id": [1, 2]}))
+                    else:
+                        _write_csv(path, pd.DataFrame({"id": [1, 2]}))
                 return AtlasPreprocessOutputs(
                     atlas_mutable_input_dir=atlas_input_dir,
                     prepared_inputs=outputs,

--- a/tests/test_restart_stage_boundary_matrix.py
+++ b/tests/test_restart_stage_boundary_matrix.py
@@ -612,6 +612,10 @@ def restart_stage_env(tmp_path, monkeypatch):
         beam_dir / settings.run.region / settings.shared.skims.fname
     )
     _write_file(beam_dir / settings.run.region / settings.beam.config, "beam-config")
+    _write_file(
+        atlas_output_dir / f"vehicles2_{state.forecast_year}.csv",
+        "vehicleId,householdId,vehicleTypeId\n1,10,sedan\n",
+    )
 
     def record_builder(model_name, phase):
         if phase == "preprocess":

--- a/tests/test_run_notifications.py
+++ b/tests/test_run_notifications.py
@@ -215,8 +215,8 @@ def test_notifier_filters_to_scenario_headers_and_child_runs() -> None:
     notifier.on_run_start(_run("workspace_setup"))
 
     assert [message.fallback_text for message in backend.messages] == [
-        "PILATES run started: scenario",
-        "PILATES step started: step",
+        "🚀 PILATES run started: scenario",
+        "🚀 PILATES step started: step",
     ]
 
 
@@ -229,8 +229,26 @@ def test_notifier_always_reports_internal_failures() -> None:
 
     notifier.on_run_failed(_run("workspace_setup"), RuntimeError("boom"))
 
-    assert backend.messages[0].fallback_text == "PILATES step failed: workspace_setup"
+    assert backend.messages[0].fallback_text == "⚠️ PILATES step failed: workspace_setup"
     assert "error: boom" in backend.messages[0].markdown_text
+    assert "Next: inspect the run archive and summary HTML" in backend.messages[0].markdown_text
+
+
+def test_notifier_failure_includes_next_place_to_look() -> None:
+    backend = FakeBackend()
+    notifier = run_notifications.ConsistRunNotifier(
+        settings=_enabled_settings(),
+        backends=[backend],
+        context=RunNotificationContext(archive_run_dir="/global/scratch/run"),
+    )
+
+    notifier.on_run_failed(
+        _run("failed_step", parent_run_id="scenario"),
+        RuntimeError("boom"),
+    )
+
+    text = backend.messages[0].markdown_text
+    assert "Next: inspect `/global/scratch/run/.pilates/run_summary.html`" in text
 
 
 def test_notifier_verbose_mode_includes_internal_runs() -> None:
@@ -242,7 +260,7 @@ def test_notifier_verbose_mode_includes_internal_runs() -> None:
 
     notifier.on_run_start(_run("workspace_setup"))
 
-    assert backend.messages[0].fallback_text == "PILATES step started: workspace_setup"
+    assert backend.messages[0].fallback_text == "🚀 PILATES step started: workspace_setup"
 
 
 def test_notifier_scenario_message_includes_run_user_job_and_archive() -> None:
@@ -318,7 +336,7 @@ def test_notifier_step_message_is_compact_and_scannable() -> None:
     message = backend.messages[0]
     assert (
         message.fallback_text
-        == "PILATES step completed: y2020 | i0 | traffic_assignment_abcdef0"
+        == "✅ PILATES step completed: y2020 | i0 | traffic_assignment_abcdef0"
     )
     assert message.thread_key == "pilates-run--sfbay--baseline"
     assert "Step: `beam_run`" in message.markdown_text
@@ -348,6 +366,52 @@ def test_notifier_complete_message_marks_executed_result() -> None:
     )
 
     assert "Result: executed" in backend.messages[0].markdown_text
+
+
+def test_notifier_appends_scenario_recap_on_completion() -> None:
+    backend = FakeBackend()
+    notifier = run_notifications.ConsistRunNotifier(
+        settings=_enabled_settings(),
+        backends=[backend],
+        context=RunNotificationContext(
+            run_name="pilates-run--sfbay--baseline",
+            archive_run_dir="/global/scratch/run",
+        ),
+    )
+
+    notifier.on_run_complete(
+        _run(
+            "pilates-run--sfbay--baseline__step_func__y2020__i0__phase_a_aaaaaaa",
+            parent_run_id="pilates-run--sfbay--baseline",
+            meta={"cache_hit": True},
+        ),
+        outputs=[],
+    )
+    notifier.on_run_complete(
+        _run(
+            "pilates-run--sfbay--baseline__step_func__y2021__i0__phase_b_bbbbbbb",
+            parent_run_id="pilates-run--sfbay--baseline",
+        ),
+        outputs=[],
+    )
+    notifier.on_run_failed(
+        _run(
+            "pilates-run--sfbay--baseline__step_func__y2022__i0__phase_c_ccccccc",
+            parent_run_id="pilates-run--sfbay--baseline",
+        ),
+        RuntimeError("bad"),
+    )
+    notifier.on_run_complete(
+        _run(
+            "pilates-run--sfbay--baseline",
+            tags=["scenario_header"],
+            model_name="pilates_orchestrator",
+        ),
+        outputs=[],
+    )
+
+    text = backend.messages[-1].markdown_text
+    assert "Recap: 2 steps completed, 1 cache hit, 1 failure" in text
 
 
 def test_notifier_truncates_long_failure_errors() -> None:
@@ -385,9 +449,9 @@ def test_register_consist_run_notification_hooks_uses_fake_backend() -> None:
     tracker.emit_failed(_run("bad_step", parent_run_id="scenario"), ValueError("bad"))
 
     assert [message.fallback_text for message in backend.messages] == [
-        "PILATES run started: scenario",
-        "PILATES step completed: step",
-        "PILATES step failed: bad_step",
+        "🚀 PILATES run started: scenario",
+        "✅ PILATES step completed: step",
+        "⚠️ PILATES step failed: bad_step",
     ]
 
 
@@ -434,14 +498,14 @@ def test_register_consist_run_notification_hooks_with_real_consist_scenario(
         )
 
     messages = [message.fallback_text for message in backend.messages]
-    assert messages[0] == "PILATES run started: smoke_scenario"
+    assert messages[0] == "🚀 PILATES run started: smoke_scenario"
     assert any(
-        message.startswith("PILATES step started: smoke_step") for message in messages
+        message.startswith("🚀 PILATES step started: smoke_step") for message in messages
     )
     assert any(
-        message.startswith("PILATES step completed: smoke_step") for message in messages
+        message.startswith("✅ PILATES step completed: smoke_step") for message in messages
     )
-    assert messages[-1] == "PILATES run completed: smoke_scenario"
+    assert messages[-1] == "✅ PILATES run completed: smoke_scenario"
 
 
 def test_slack_backend_posts_block_payload(monkeypatch) -> None:
@@ -454,7 +518,7 @@ def test_slack_backend_posts_block_payload(monkeypatch) -> None:
 
     backend.send(
         RunNotificationMessage(
-            title="PILATES run started",
+            title="🚀 PILATES run started",
             run_id="run-a",
             lines=("run_id: `run-a`",),
             thread_key="run-a",
@@ -464,7 +528,7 @@ def test_slack_backend_posts_block_payload(monkeypatch) -> None:
     url, payload, timeout = recorded.calls[0]
     assert url == "https://hooks.slack.com/services/T/B/C"
     assert timeout == 3.0
-    assert payload["text"] == "PILATES run started: run-a"
+    assert payload["text"] == "🚀 PILATES run started: run-a"
     assert "blocks" in payload
 
 
@@ -478,7 +542,7 @@ def test_google_chat_backend_posts_threaded_payload(monkeypatch) -> None:
 
     backend.send(
         RunNotificationMessage(
-            title="PILATES run started",
+            title="🚀 PILATES run started",
             run_id="run-a",
             lines=("run_id: `run-a`",),
             thread_key="run-a",
@@ -492,6 +556,6 @@ def test_google_chat_backend_posts_threaded_payload(monkeypatch) -> None:
     )
     assert timeout == 4.0
     assert payload == {
-        "text": "*PILATES run started*\n- run_id: run-a",
+        "text": "*🚀 PILATES run started*\n- run_id: run-a",
         "thread": {"threadKey": "run-a"},
     }

--- a/tests/test_run_notifications.py
+++ b/tests/test_run_notifications.py
@@ -231,7 +231,10 @@ def test_notifier_always_reports_internal_failures() -> None:
 
     assert backend.messages[0].fallback_text == "⚠️ PILATES step failed: workspace_setup"
     assert "error: boom" in backend.messages[0].markdown_text
-    assert "Next: inspect the run archive and summary HTML" in backend.messages[0].markdown_text
+    assert (
+        "Next: inspect the run archive and summary HTML"
+        in backend.messages[0].markdown_text
+    )
 
 
 def test_notifier_failure_includes_next_place_to_look() -> None:
@@ -260,7 +263,9 @@ def test_notifier_verbose_mode_includes_internal_runs() -> None:
 
     notifier.on_run_start(_run("workspace_setup"))
 
-    assert backend.messages[0].fallback_text == "🚀 PILATES step started: workspace_setup"
+    assert (
+        backend.messages[0].fallback_text == "🚀 PILATES step started: workspace_setup"
+    )
 
 
 def test_notifier_scenario_message_includes_run_user_job_and_archive() -> None:
@@ -500,10 +505,12 @@ def test_register_consist_run_notification_hooks_with_real_consist_scenario(
     messages = [message.fallback_text for message in backend.messages]
     assert messages[0] == "🚀 PILATES run started: smoke_scenario"
     assert any(
-        message.startswith("🚀 PILATES step started: smoke_step") for message in messages
+        message.startswith("🚀 PILATES step started: smoke_step")
+        for message in messages
     )
     assert any(
-        message.startswith("✅ PILATES step completed: smoke_step") for message in messages
+        message.startswith("✅ PILATES step completed: smoke_step")
+        for message in messages
     )
     assert messages[-1] == "✅ PILATES run completed: smoke_scenario"
 

--- a/tests/test_stage_contracts.py
+++ b/tests/test_stage_contracts.py
@@ -888,6 +888,10 @@ def test_vehicle_ownership_stage_contract(stage_env):
         build_atlas_static_inputs_fallback=lambda workspace: {},
     )
     assert stage_env["coupler"].get(USIM_DATASTORE_H5) is not None
+    assert stage_env["coupler"].get(USIM_POPULATION_SOURCE_H5) is not None
+    assert stage_env["coupler"].get(USIM_DATASTORE_CURRENT_H5) == stage_env[
+        "coupler"
+    ].get(USIM_POPULATION_SOURCE_H5)
 
 
 def test_vehicle_ownership_stage_prefers_explicit_beam_skims_artifact(stage_env):
@@ -1746,6 +1750,9 @@ def test_supply_demand_activitysim_postprocess_binds_population_source_to_foreca
     )
     _write_file(current_h5)
     _write_population_h5(forecast_h5, forecast_year)
+    atlas_output_dir = Path(stage_env["workspace"].get_atlas_output_dir())
+    atlas_output_dir.mkdir(parents=True, exist_ok=True)
+    _write_file(atlas_output_dir / f"vehicles2_{forecast_year}.csv")
 
     state = stage_env["state"]
     state.current_year = current_year

--- a/tests/test_stage_contracts.py
+++ b/tests/test_stage_contracts.py
@@ -190,6 +190,13 @@ def _write_population_h5(path: Path, year: int) -> None:
             store.put(f"/{year}/{table_name}", pd.DataFrame({"value": [1]}))
 
 
+def _write_root_population_h5(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with pd.HDFStore(path, mode="w") as store:
+        for table_name in ("households", "persons", "jobs", "blocks"):
+            store.put(f"/{table_name}", pd.DataFrame({"value": [1]}))
+
+
 def _build_settings(tmp_path: Path):
     """Build a compact workflow config that exercises all stage contracts."""
 
@@ -570,6 +577,7 @@ def test_land_use_stage_contract(stage_env):
     """Land use must publish datastore handles needed by later stages."""
     from pilates.workflows.steps import StepOutputsHolder
 
+    _write_root_population_h5(Path(stage_env["usim_output_path"]))
     outputs_holder = StepOutputsHolder()
 
     usim_inputs = run_land_use_stage(
@@ -591,6 +599,32 @@ def test_land_use_stage_contract(stage_env):
     assert usim_inputs[USIM_POPULATION_SOURCE_H5].endswith("_population_source.h5")
     assert stage_env["coupler"].get(USIM_DATASTORE_H5) is not None
     assert stage_env["coupler"].get(USIM_DATASTORE_BASE_H5) is not None
+
+
+def test_land_use_stage_aliases_root_population_snapshot_tables_for_non_start_year(
+    stage_env,
+):
+    """Non-start-year ActivitySim handoffs require exact-year population tables."""
+    from pilates.workflows.steps import StepOutputsHolder
+
+    state = stage_env["state"]
+    state.current_year = state.forecast_year
+    _write_root_population_h5(Path(stage_env["usim_output_path"]))
+
+    outputs_holder = StepOutputsHolder()
+    usim_inputs = run_land_use_stage(
+        scenario=stage_env["scenario"],
+        state=state,
+        settings=stage_env["settings"],
+        workspace=stage_env["workspace"],
+        coupler=stage_env["coupler"],
+        year=state.forecast_year,
+        outputs_holder_year=outputs_holder,
+    )
+
+    with pd.HDFStore(usim_inputs[USIM_POPULATION_SOURCE_H5], mode="r") as store:
+        for table_name in ("households", "persons", "jobs", "blocks"):
+            assert f"/{state.forecast_year}/{table_name}" in store
 
 
 def test_land_use_stage_returns_typed_supply_demand_handoff(stage_env):

--- a/tests/test_stage_contracts.py
+++ b/tests/test_stage_contracts.py
@@ -2726,6 +2726,13 @@ def test_traffic_assignment_restart_registers_restored_beam_under_forecast_year(
     )
     beam_config_path.unlink()
 
+    atlas_output_dir = Path(workspace.get_atlas_output_dir())
+    forecast_vehicles2_path = atlas_output_dir / f"vehicles2_{state.forecast_year}.csv"
+    forecast_vehicles2_path.write_text(
+        "vehicleId,householdId,vehicleTypeId\n1,10,sedan\n",
+        encoding="utf-8",
+    )
+
     beam_out = Path(workspace.get_beam_output_dir())
     linkstats = beam_out / "0.linkstats.csv.gz"
     events = beam_out / "0.events.parquet"

--- a/tests/test_urbansim_atlas_typed_contracts.py
+++ b/tests/test_urbansim_atlas_typed_contracts.py
@@ -369,6 +369,54 @@ def test_atlas_preprocess_outputs_require_grave_csv_for_non_start_year(
         )
 
 
+def test_atlas_preprocess_outputs_reject_stale_households_csv_for_selected_h5(
+    tmp_path: Path,
+) -> None:
+    h5_path = tmp_path / "model_data_2021.h5"
+    pd.DataFrame(
+        {"cars": [1, 2]},
+        index=pd.Index([10, 20], name="household_id"),
+    ).to_hdf(h5_path, key="/households", mode="w")
+
+    prepared_inputs = {}
+    for key, filename, contents in (
+        (
+            "atlas_households_csv",
+            "households.csv",
+            "household_id,cars\n1,1\n2,2\n",
+        ),
+        ("atlas_blocks_csv", "blocks.csv", "x\n"),
+        ("atlas_persons_csv", "persons.csv", "x\n"),
+        ("atlas_residential_csv", "residential.csv", "x\n"),
+        ("atlas_jobs_csv", "jobs.csv", "x\n"),
+        ("atlas_grave_csv", "grave.csv", "x\n"),
+    ):
+        path = tmp_path / "atlas-input" / "year2021" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+        prepared_inputs[key] = path
+
+    outputs = AtlasPreprocessOutputs(
+        atlas_mutable_input_dir=tmp_path / "atlas-input",
+        prepared_inputs=prepared_inputs,
+    )
+
+    with pytest.raises(AssertionError, match="different population universe"):
+        outputs.validate(
+            context=ValidationContext(
+                step_name="atlas_preprocess",
+                state=SimpleNamespace(
+                    start_year=2017,
+                    year=2021,
+                    current_year=2021,
+                    atlas_usim_datastore_h5=str(h5_path),
+                    is_start_year=lambda: False,
+                ),
+                workspace=SimpleNamespace(full_path=str(tmp_path)),
+            )
+        )
+
+
 def test_atlas_runner_retries_container_exceptions(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_workflow_binding.py
+++ b/tests/test_workflow_binding.py
@@ -560,6 +560,41 @@ def test_activitysim_preprocess_binding_rejects_root_only_forecast_h5_for_non_st
         )
 
 
+def test_activitysim_preprocess_binding_repairs_population_snapshot_root_tables(
+    tmp_path,
+):
+    h5_path = tmp_path / "model_data_2021_population_source.h5"
+    with pd.HDFStore(h5_path, mode="w") as store:
+        for table_name in ("households", "persons", "jobs", "blocks"):
+            store.put(f"/{table_name}", pd.DataFrame({"value": [1]}))
+
+    state = SimpleNamespace(
+        year=2021,
+        forecast_year=2021,
+        Stage=SimpleNamespace(land_use="land_use"),
+        is_enabled=lambda stage: stage == "land_use",
+        is_start_year=lambda: False,
+    )
+
+    plan = build_binding_plan(
+        step_name="activitysim_preprocess",
+        fallback_inputs={USIM_POPULATION_SOURCE_H5: str(h5_path)},
+        settings=SimpleNamespace(),
+        state=state,
+        workspace=SimpleNamespace(),
+        year=2021,
+    )
+
+    assert (
+        plan.metadata["resolved_values_by_semantic_key"][
+            USIM_POPULATION_HOUSEHOLDS_TABLE
+        ]
+        == "/2021/households"
+    )
+    with pd.HDFStore(h5_path, mode="r") as store:
+        assert "/2021/households" in store
+
+
 def test_activitysim_population_source_uses_forecast_year_when_planner_threads_current_year(
     tmp_path,
 ):

--- a/tests/test_workflow_binding.py
+++ b/tests/test_workflow_binding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import consist
@@ -732,6 +733,53 @@ def test_beam_preprocess_atlas_inputs_falls_back_to_forecast_year_minus_one(
     )
 
     assert plan.inputs[ATLAS_VEHICLES2_OUTPUT] == str(prior_year_h5)
+
+
+def test_beam_preprocess_atlas_inputs_use_forecast_year_archive_candidate(
+    tmp_path,
+):
+    local_root = tmp_path / "local-run"
+    archive_root = tmp_path / "archive-run"
+    atlas_rel = Path("atlas") / "atlas_output"
+    archive_vehicles = archive_root / atlas_rel / "vehicles2_2030.csv"
+    archive_vehicles.parent.mkdir(parents=True)
+    archive_vehicles.write_text("archive forecast vehicles", encoding="utf-8")
+
+    settings = SimpleNamespace(
+        run=SimpleNamespace(models=SimpleNamespace(traffic_assignment="beam"))
+    )
+    state = SimpleNamespace(
+        current_inner_iter=0,
+        forecast_year=2030,
+        year=2024,
+        run_info_path=str(archive_root / "run_state.yaml"),
+    )
+    workspace = SimpleNamespace(
+        full_path=str(local_root),
+        get_atlas_output_dir=lambda: str(local_root / atlas_rel),
+    )
+
+    plan = build_binding_plan(
+        step_name="unit_test_beam_preprocess",
+        artifact_rules=(
+            ArtifactBindingRule(
+                semantic_key=ATLAS_VEHICLES2_OUTPUT,
+                required=False,
+                allow_fallback=True,
+                fallback_provider="beam_preprocess_atlas_inputs",
+            ),
+        ),
+        settings=settings,
+        state=state,
+        workspace=workspace,
+        year=state.year,
+        surface=_surface_stub(
+            activity_demand_enabled=True,
+            vehicle_ownership_model_enabled=True,
+        ),
+    )
+
+    assert plan.inputs[ATLAS_VEHICLES2_OUTPUT] == str(archive_vehicles)
 
 
 def test_build_binding_plan_uses_activitysim_postprocess_base_datastore_provider(

--- a/tests/test_workflow_binding.py
+++ b/tests/test_workflow_binding.py
@@ -340,6 +340,107 @@ def test_beam_preprocess_binding_plan_prefers_current_atlas_vehicle_with_activit
     assert plan.source_by_key[ATLAS_VEHICLES2_OUTPUT] == "explicit"
 
 
+def test_beam_preprocess_binding_plan_uses_archive_exact_year_vehicle_over_coupler(
+    monkeypatch, tmp_path
+):
+    from pilates.workflows import binding as binding_module
+
+    monkeypatch.setattr(
+        binding_module,
+        "_beam_preprocess_warmstart_inputs",
+        lambda **_: None,
+    )
+    local_root = tmp_path / "local-run"
+    archive_root = tmp_path / "archive-run"
+    atlas_rel = Path("atlas") / "atlas_output"
+    archive_vehicles = archive_root / atlas_rel / "vehicles2_2030.csv"
+    archive_vehicles.parent.mkdir(parents=True)
+    archive_vehicles.write_text("archive forecast vehicles", encoding="utf-8")
+
+    plan = beam_preprocess_binding_plan(
+        coupler=_CouplerStub({ATLAS_VEHICLES2_OUTPUT: "/tmp/stale-vehicles.csv.gz"}),
+        settings=SimpleNamespace(
+            run=SimpleNamespace(
+                models=SimpleNamespace(
+                    activity_demand="activitysim",
+                    traffic_assignment="beam",
+                )
+            ),
+            vehicle_ownership_model_enabled=True,
+        ),
+        state=SimpleNamespace(
+            current_inner_iter=0,
+            forecast_year=2030,
+            year=2030,
+            run_info_path=str(archive_root / "run_state.yaml"),
+        ),
+        workspace=SimpleNamespace(
+            full_path=str(local_root),
+            get_atlas_output_dir=lambda: str(local_root / atlas_rel),
+        ),
+        year=2030,
+        activity_demand_outputs={},
+        previous_beam_outputs=None,
+        surface=_surface_stub(
+            activity_demand_enabled=True,
+            vehicle_ownership_model_enabled=True,
+        ),
+    )
+
+    assert plan.inputs[ATLAS_VEHICLES2_OUTPUT] == str(archive_vehicles)
+
+
+def test_beam_preprocess_binding_plan_rejects_prior_year_vehicle_for_activity_outputs(
+    monkeypatch, tmp_path
+):
+    from pilates.workflows import binding as binding_module
+
+    monkeypatch.setattr(
+        binding_module,
+        "_beam_preprocess_warmstart_inputs",
+        lambda **_: None,
+    )
+    local_root = tmp_path / "local-run"
+    archive_root = tmp_path / "archive-run"
+    atlas_rel = Path("atlas") / "atlas_output"
+    prior_vehicles = archive_root / atlas_rel / "vehicles2_2029.csv"
+    prior_vehicles.parent.mkdir(parents=True)
+    prior_vehicles.write_text("archive prior vehicles", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="exact forecast-year ATLAS vehicles2"):
+        beam_preprocess_binding_plan(
+            coupler=_CouplerStub(
+                {ATLAS_VEHICLES2_OUTPUT: "/tmp/stale-vehicles.csv.gz"}
+            ),
+            settings=SimpleNamespace(
+                run=SimpleNamespace(
+                    models=SimpleNamespace(
+                        activity_demand="activitysim",
+                        traffic_assignment="beam",
+                    )
+                ),
+                vehicle_ownership_model_enabled=True,
+            ),
+            state=SimpleNamespace(
+                current_inner_iter=0,
+                forecast_year=2030,
+                year=2030,
+                run_info_path=str(archive_root / "run_state.yaml"),
+            ),
+            workspace=SimpleNamespace(
+                full_path=str(local_root),
+                get_atlas_output_dir=lambda: str(local_root / atlas_rel),
+            ),
+            year=2030,
+            activity_demand_outputs={},
+            previous_beam_outputs=None,
+            surface=_surface_stub(
+                activity_demand_enabled=True,
+                vehicle_ownership_model_enabled=True,
+            ),
+        )
+
+
 def test_beam_preprocess_binding_plan_prefers_restored_atlas_vehicle_without_activity_outputs(
     monkeypatch,
 ):

--- a/tests/test_workflow_invariants.py
+++ b/tests/test_workflow_invariants.py
@@ -1076,7 +1076,7 @@ def test_atlas_preprocess_output_replayer_restores_restart_prior_subyear_inputs(
     assert (current_atlas_input_dir / "year2021" / "grave.csv").exists()
     assert (current_atlas_input_dir / "year2021" / "vehicles_output.RData").exists()
     assert (current_atlas_input_dir / "year2021" / "households_output.RData").exists()
-    assert getattr(outputs, "_compatibility_fallback_used", False) is True
+    assert getattr(outputs, "_restart_rehydration_used", False) is True
 
 
 def test_manifest_restore_reruns_atlas_stage_when_restart_subyear_grave_csv_missing(

--- a/tests/test_workflow_step_metadata.py
+++ b/tests/test_workflow_step_metadata.py
@@ -1134,7 +1134,7 @@ def test_activitysim_postprocess_ignores_missing_optional_declared_output_paths(
 
     call = scenario.calls[0]
     assert call["output_paths"][USIM_DATASTORE_H5] == str(
-        tmp_path / "urbansim" / "data" / "forecast_2020.h5"
+        tmp_path / "urbansim" / "data" / "custom_53199100.h5"
     )
     assert "asim_input_skims_omx_archived" in call["output_paths"]
     assert "asim_input_skims_zarr_archived" in call["output_paths"]

--- a/tests/test_workflow_step_metadata.py
+++ b/tests/test_workflow_step_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 from consist import define_step
 from consist.types import BindingResult
@@ -479,6 +480,68 @@ def test_atlas_step_metadata_config_includes_parent_forecast_year():
     assert config["main_forecast_year"] == 2029
     assert facet["atlas_subyear"] == 2023
     assert facet["main_forecast_year"] == 2029
+
+
+def test_atlas_step_metadata_config_fingerprints_selected_usim_households(
+    tmp_path: Path,
+):
+    def _write_h5(path: Path, household_ids: list[int]) -> None:
+        households = pd.DataFrame(
+            {"cars": [1 for _ in household_ids]},
+            index=pd.Index(household_ids, name="household_id"),
+        )
+        with pd.HDFStore(path, mode="w") as store:
+            store.put("/households", households)
+
+    first_h5 = tmp_path / "first.h5"
+    second_h5 = tmp_path / "second.h5"
+    _write_h5(first_h5, [1, 2, 3])
+    _write_h5(second_h5, [10, 20, 30])
+
+    coupler = _DummyCoupler()
+    holder = StepOutputsHolder()
+    step = make_atlas_preprocess_step(coupler=coupler, outputs_holder=holder)
+    meta = step.__consist_step__
+
+    settings = SimpleNamespace(
+        run=SimpleNamespace(),
+        activitysim=None,
+        beam=None,
+        urbansim=None,
+        postprocessing=None,
+        atlas=SimpleNamespace(model_dump=lambda: {"max_retries": 1}),
+    )
+    workspace = SimpleNamespace(full_path=str(tmp_path))
+
+    class _Ctx:
+        def __init__(self, h5_path: Path):
+            self._runtime = {
+                "settings": settings,
+                "workspace": workspace,
+                "state": SimpleNamespace(
+                    year=2021,
+                    start_year=2020,
+                    current_year=2021,
+                    forecast_year=2021,
+                    main_forecast_year=2021,
+                    atlas_usim_datastore_h5=str(h5_path),
+                ),
+            }
+
+        def get_runtime(self, name, default=None):
+            return self._runtime.get(name, default)
+
+    first_config = meta.config(_Ctx(first_h5))
+    second_config = meta.config(_Ctx(second_h5))
+
+    assert first_config["atlas_usim_households_identity_status"] == "resolved"
+    assert first_config["atlas_usim_households_table_path"] == "/households"
+    assert first_config["atlas_usim_households_requested_year"] == 2021
+    assert first_config["atlas_usim_households_row_count"] == 3
+    assert (
+        first_config["atlas_usim_households_sha256"]
+        != second_config["atlas_usim_households_sha256"]
+    )
 
 
 def test_urbansim_run_declares_strict_output_contract():


### PR DESCRIPTION
## Summary

This branch adds the end-to-end archive promotion path for completed PILATES runs and hardens the restart/staging plumbing that feeds it. The main goal is to make a finished HPC run safely promotable from scratch storage to long-term recovery roots without losing Consist lineage or artifact metadata.

## What Changed

- Added `pilates.runtime.promote_run_archive` and `docs/run/run_promotion.md` to support promoting a completed archive run to one or more recovery roots, verifying the promoted copy, and optionally merging only the new root subtree into the main Consist DB.
- Introduced recovery-root adoption helpers so copied artifacts are registered back into Consist with durable storage metadata instead of relying on the older recovery-root setter path.
- Fixed exact-year UrbanSim population-source H5 aliasing and updated archive copy handling so promoted runs keep the correct root metadata.
- Hardened BEAM, ATLAS, and ActivitySim staging and restart paths, including vehicle source selection, staged vehicle filtering, clobber prevention, and metadata persistence.
- Updated workflow binding, step metadata, and run notification output so the new promotion and recovery-root behavior is carried through the orchestration path.