### PR TITLE
fix: bind BEAM postprocess to current outputs and stabilize skim naming

### DIFF
--- a/pilates/beam/launch_config.py
+++ b/pilates/beam/launch_config.py
@@ -39,6 +39,9 @@ _ARTIFACT_FORMAT_POLICY_KEYS = {
     "events": "beam.outputs.events.fileOutputFormats",
     "linkstats": "beam.physsim.linkStatsOutputFileType",
 }
+_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY = (
+    "beam.router.skim.activity-sim-skimmer.fileBaseName"
+)
 
 
 def _warmstart_destination_name(source: Path) -> str:
@@ -250,6 +253,12 @@ def build_beam_launch_config(
         env_overrides=env_overrides,
     )
     overrides.update(format_overrides)
+    skim_name_overrides = _activitysim_skims_file_base_name_override(
+        settings=settings,
+        source_primary=source_primary,
+        env_overrides=env_overrides,
+    )
+    overrides.update(skim_name_overrides)
     population_stems = {
         BEAM_PLANS_IN: "plans",
         BEAM_HOUSEHOLDS_IN: "households",
@@ -332,6 +341,37 @@ def build_beam_launch_config(
         staged_inputs=tuple(staged_inputs),
         allow_missing_override_keys=introduces_missing_format_key,
     )
+
+
+def _activitysim_skims_file_base_name_override(
+    *,
+    settings: Any,
+    source_primary: Path,
+    env_overrides: Mapping[str, str],
+) -> dict[str, str]:
+    """Return the configured BEAM activity-sim skimmer writer base name."""
+
+    expected = settings.beam.activitysim_skims_file_base_name
+    source_value = resolve_beam_config_value(
+        source_primary,
+        key=_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY,
+        env_overrides=dict(env_overrides),
+    )
+    if source_value is None:
+        raise KeyError(
+            "PILATES requires BEAM config key "
+            f"{_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY!r} to make activity-sim "
+            "skim output naming deterministic."
+        )
+    elif str(source_value) != expected:
+        logger.warning(
+            "PILATES activity-sim skim filename policy overrides source config: "
+            "%s=%r -> %r.",
+            _ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY,
+            source_value,
+            expected,
+        )
+    return {_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY: expected}
 
 
 def _artifact_format_overrides(

--- a/pilates/beam/launch_config.py
+++ b/pilates/beam/launch_config.py
@@ -192,7 +192,12 @@ def _require_declared_non_policy_overrides(
 ) -> None:
     """Preserve strict validation when a legacy format key must be introduced."""
 
-    policy_keys = frozenset(_ARTIFACT_FORMAT_POLICY_KEYS.values())
+    policy_keys = frozenset(
+        (
+            _ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY,
+            *_ARTIFACT_FORMAT_POLICY_KEYS.values(),
+        )
+    )
     environment = beam_config_env_overrides(settings, config_root=source_primary.parent)
     for key in override_keys:
         if key == "beam.inputDirectory" or key in policy_keys:
@@ -253,10 +258,12 @@ def build_beam_launch_config(
         env_overrides=env_overrides,
     )
     overrides.update(format_overrides)
-    skim_name_overrides = _activitysim_skims_file_base_name_override(
-        settings=settings,
-        source_primary=source_primary,
-        env_overrides=env_overrides,
+    skim_name_overrides, introduces_missing_skim_name_key = (
+        _activitysim_skims_file_base_name_override(
+            settings=settings,
+            source_primary=source_primary,
+            env_overrides=env_overrides,
+        )
     )
     overrides.update(skim_name_overrides)
     population_stems = {
@@ -339,7 +346,9 @@ def build_beam_launch_config(
         identity=identity,
         overrides=BeamLaunchConfigOverrides(values=overrides),
         staged_inputs=tuple(staged_inputs),
-        allow_missing_override_keys=introduces_missing_format_key,
+        allow_missing_override_keys=(
+            introduces_missing_format_key or introduces_missing_skim_name_key
+        ),
     )
 
 
@@ -348,7 +357,7 @@ def _activitysim_skims_file_base_name_override(
     settings: Any,
     source_primary: Path,
     env_overrides: Mapping[str, str],
-) -> dict[str, str]:
+) -> tuple[dict[str, str], bool]:
     """Return the configured BEAM activity-sim skimmer writer base name."""
 
     expected = settings.beam.activitysim_skims_file_base_name
@@ -358,10 +367,11 @@ def _activitysim_skims_file_base_name_override(
         env_overrides=dict(env_overrides),
     )
     if source_value is None:
-        raise KeyError(
-            "PILATES requires BEAM config key "
-            f"{_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY!r} to make activity-sim "
-            "skim output naming deterministic."
+        logger.warning(
+            "PILATES activity-sim skim filename policy adds source config key "
+            "%s=%r; the legacy config relied on BEAM's implicit default.",
+            _ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY,
+            expected,
         )
     elif str(source_value) != expected:
         logger.warning(
@@ -371,7 +381,7 @@ def _activitysim_skims_file_base_name_override(
             source_value,
             expected,
         )
-    return {_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY: expected}
+    return {_ACTIVITYSIM_SKIMS_FILE_BASE_NAME_KEY: expected}, source_value is None
 
 
 def _artifact_format_overrides(

--- a/pilates/beam/runner.py
+++ b/pilates/beam/runner.py
@@ -642,7 +642,11 @@ class BeamRunner(GenericRunner):
         output_records = self.gather_outputs(
             output_path_for_gather,
             skimFormat,
-            settings.beam.activitysim_skims_file_base_name,
+            get_setting(
+                settings,
+                "beam.activitysim_skims_file_base_name",
+                "skimsActivitySimOD",
+            ),
         )
         output_store = RecordStore(recordList=output_records)
 

--- a/pilates/beam/runner.py
+++ b/pilates/beam/runner.py
@@ -313,7 +313,17 @@ class BeamRunner(GenericRunner):
         self,
         beam_local_output_folder: str,
         skimFormat: str = "omx",
+        activitysim_skims_file_base_name: str = "skimsActivitySimOD",
     ) -> List[FileRecord]:
+        activitysim_skim_base_names = tuple(
+            dict.fromkeys(
+                (
+                    activitysim_skims_file_base_name,
+                    "skimsActivitySimOD",
+                    "activitySimODSkims",
+                )
+            )
+        )
         files_to_get = {
             "raw_od_skims": ("skimsActivitySimOD_current", ".omx"),
             # BEAM OD skims naming differs across builds/configs:
@@ -388,16 +398,30 @@ class BeamRunner(GenericRunner):
         for it, path in paths.items():
             for short_name, (file_name, extension) in files_to_get.items():
                 if short_name == "raw_od_skims":
-                    full_path = find_iteration_file(
-                        path, it, "skimsActivitySimOD_current", ".omx"
-                    ) or find_iteration_file(
-                        path, it, "activitySimODSkims_current", ".omx"
+                    full_path = next(
+                        (
+                            candidate
+                            for base_name in activitysim_skim_base_names
+                            if (
+                                candidate := find_iteration_file(
+                                    path, it, f"{base_name}_current", ".omx"
+                                )
+                            )
+                        ),
+                        None,
                     )
                 elif short_name == "raw_od_skims_zarr":
-                    full_path = find_iteration_file(
-                        path, it, "skimsActivitySimOD_current", ".zarr"
-                    ) or find_iteration_file(
-                        path, it, "activitySimODSkims_current", ".zarr"
+                    full_path = next(
+                        (
+                            candidate
+                            for base_name in activitysim_skim_base_names
+                            if (
+                                candidate := find_iteration_file(
+                                    path, it, f"{base_name}_current", ".zarr"
+                                )
+                            )
+                        ),
+                        None,
                     )
                 else:
                     full_path = find_iteration_file(path, it, file_name, extension)
@@ -615,7 +639,11 @@ class BeamRunner(GenericRunner):
                 "[BEAM Runner] Defaulting to 'omx' skim format for finding BEAM outputs."
             )
 
-        output_records = self.gather_outputs(output_path_for_gather, skimFormat)
+        output_records = self.gather_outputs(
+            output_path_for_gather,
+            skimFormat,
+            settings.beam.activitysim_skims_file_base_name,
+        )
         output_store = RecordStore(recordList=output_records)
 
         logger.info(

--- a/pilates/config/models.py
+++ b/pilates/config/models.py
@@ -692,6 +692,14 @@ class BeamConfig(BaseModel):
             "If relative, it is resolved against the mutable BEAM region input root."
         ),
     )
+    activitysim_skims_file_base_name: str = Field(
+        "skimsActivitySimOD",
+        min_length=1,
+        description=(
+            "BEAM activity-sim skimmer fileBaseName. BEAM appends its current "
+            "marker and the configured artifact-format extension."
+        ),
+    )
     artifact_formats: BeamArtifactFormatsConfig = Field(
         default_factory=BeamArtifactFormatsConfig,
         description=(

--- a/pilates/workflows/stages/supply_demand_beam.py
+++ b/pilates/workflows/stages/supply_demand_beam.py
@@ -1082,6 +1082,7 @@ def _run_beam_steps(
         state=state,
         workspace=workspace,
         coupler=scenario.coupler,
+        beam_run_outputs=run_result.outputs,
     )
     postprocess_inputs.require_complete()
     _publish_completed_beam_run_checkpoint(

--- a/pilates/workflows/stages/supply_demand_beam.py
+++ b/pilates/workflows/stages/supply_demand_beam.py
@@ -1064,7 +1064,7 @@ def _run_beam_steps(
         coupler=scenario.coupler,
         launch_config=launch_config,
     )
-    run_result, _ = execute_step(
+    run_result, beam_run_outputs = execute_step(
         scenario=scenario,
         definition=beam_run,
         settings=settings,
@@ -1082,7 +1082,7 @@ def _run_beam_steps(
         state=state,
         workspace=workspace,
         coupler=scenario.coupler,
-        beam_run_outputs=run_result.outputs,
+        beam_run_outputs=beam_run_outputs,
     )
     postprocess_inputs.require_complete()
     _publish_completed_beam_run_checkpoint(

--- a/pilates/workflows/steps/beam.py
+++ b/pilates/workflows/steps/beam.py
@@ -977,7 +977,7 @@ def _resolve_beam_postprocess_inputs(
     state: Any,
     workspace: Any,
     coupler: Any,
-    beam_run_outputs: Mapping[str, Any] | None = None,
+    beam_run_outputs: Mapping[str, Any] | BeamRunOutputs | None = None,
 ) -> ResolvedStepInputs:
     """Resolve one BEAM postprocess closure.
 
@@ -990,9 +990,14 @@ def _resolve_beam_postprocess_inputs(
     if year is None:
         raise RuntimeError("beam_postprocess requires a resolved forecast year.")
     iteration = state.iteration
+    fresh_outputs = (
+        beam_run_outputs.raw_outputs
+        if isinstance(beam_run_outputs, BeamRunOutputs)
+        else beam_run_outputs
+    )
     storage_keys = (
-        beam_run_outputs.keys()
-        if beam_run_outputs is not None
+        fresh_outputs.keys()
+        if fresh_outputs is not None
         else coupler_storage_keys(coupler)
     )
     dynamic_keys = _postprocess_dynamic_keys(
@@ -1024,8 +1029,8 @@ def _resolve_beam_postprocess_inputs(
         required_roles=dynamic_keys,
         optional_roles=optional_roles,
         explicit_inputs=(
-            {key: beam_run_outputs[key] for key in dynamic_keys}
-            if beam_run_outputs is not None
+            {key: fresh_outputs[key] for key in dynamic_keys}
+            if fresh_outputs is not None
             else None
         ),
         logical_destinations=destinations,

--- a/pilates/workflows/steps/beam.py
+++ b/pilates/workflows/steps/beam.py
@@ -825,18 +825,27 @@ def _resolve_beam_run_inputs(
 def _postprocess_dynamic_keys(
     *, storage_keys: Iterable[str], year: int, iteration: int
 ) -> tuple[str, ...]:
-    keys = tuple(storage_keys)
-    selected = [
-        key
-        for key in keys
-        if key.startswith(
-            (f"events_parquet_{year}_{iteration}", f"raw_od_skims_{year}_{iteration}")
-        )
-    ]
-    if not any(key.startswith("events_parquet_") for key in selected):
-        selected.extend(key for key in keys if key.startswith("events_parquet_"))
-    if not any(key.startswith("raw_od_skims") for key in selected):
-        selected.extend(key for key in keys if key.startswith("raw_od_skims"))
+    """Select only dynamic BEAM outputs for this exact workflow scope.
+
+    A scenario coupler accumulates prior iterations, so a postprocess invocation
+    must never recover its immediate BEAM inputs from a different iteration.
+    """
+
+    prefixes = (
+        f"events_parquet_{year}_{iteration}",
+        f"raw_od_skims_{year}_{iteration}",
+        f"raw_od_skims_zarr_{year}_{iteration}",
+    )
+    selected: list[str] = []
+    for key in storage_keys:
+        for prefix in prefixes:
+            if key == prefix:
+                selected.append(key)
+                break
+            sub_iteration = key.removeprefix(f"{prefix}_sub")
+            if key != sub_iteration and sub_iteration.isdecimal():
+                selected.append(key)
+                break
     return tuple(dict.fromkeys(selected))
 
 
@@ -963,13 +972,29 @@ def _postprocess_destination(*, key: str, workspace: Any, iteration: int) -> Pat
 
 
 def _resolve_beam_postprocess_inputs(
-    *, settings: Any, state: Any, workspace: Any, coupler: Any
+    *,
+    settings: Any,
+    state: Any,
+    workspace: Any,
+    coupler: Any,
+    beam_run_outputs: Mapping[str, Any] | None = None,
 ) -> ResolvedStepInputs:
+    """Resolve one BEAM postprocess closure.
+
+    A fresh successor consumes the exact outputs of the BEAM run that just
+    completed.  Coupler discovery remains only for standalone resolution and
+    the separate upstream ActivitySim skim role.
+    """
+
     year = resolve_forecast_year(state)
     if year is None:
         raise RuntimeError("beam_postprocess requires a resolved forecast year.")
     iteration = state.iteration
-    storage_keys = coupler_storage_keys(coupler)
+    storage_keys = (
+        beam_run_outputs.keys()
+        if beam_run_outputs is not None
+        else coupler_storage_keys(coupler)
+    )
     dynamic_keys = _postprocess_dynamic_keys(
         storage_keys=storage_keys,
         year=int(year),
@@ -998,6 +1023,11 @@ def _resolve_beam_postprocess_inputs(
         workspace=workspace,
         required_roles=dynamic_keys,
         optional_roles=optional_roles,
+        explicit_inputs=(
+            {key: beam_run_outputs[key] for key in dynamic_keys}
+            if beam_run_outputs is not None
+            else None
+        ),
         logical_destinations=destinations,
         metadata={"beam_postprocess_dynamic_paths": dynamic_paths},
     )

--- a/tests/test_beam_launch_config.py
+++ b/tests/test_beam_launch_config.py
@@ -24,6 +24,7 @@ def _settings() -> SimpleNamespace:
             router_directory=None,
             admission=None,
             artifact_formats=BeamArtifactFormatsConfig(),
+            activitysim_skims_file_base_name="skimsActivitySimOD",
         ),
         shared=SimpleNamespace(geography=SimpleNamespace(zones=None)),
     )
@@ -44,6 +45,7 @@ def _write_base_config(root: Path) -> Path:
                 '  agentsim.taz.tazIdFieldName = "taz"',
                 '  exchange.scenario.folder = ${beam.inputDirectory}"/scenario"',
                 '  exchange.scenario.fileFormat = "csv"',
+                '  router.skim.activity-sim-skimmer.fileBaseName = "activitySimODSkims"',
                 '  router.skim.activity-sim-skimmer.fileOutputFormat = "omx"',
                 '  outputs.events.fileOutputFormats = "csv.gz"',
                 '  physsim.linkStatsOutputFileType = "csv.gz"',
@@ -77,6 +79,7 @@ def _write_shared_config_tree(root: Path) -> Path:
                 '  agentsim.taz.tazIdFieldName = "taz"',
                 '  exchange.scenario.folder = ${beam.inputDirectory}"/scenario"',
                 '  exchange.scenario.fileFormat = "csv"',
+                '  router.skim.activity-sim-skimmer.fileBaseName = "activitySimODSkims"',
                 '  router.skim.activity-sim-skimmer.fileOutputFormat = "omx"',
                 '  outputs.events.fileOutputFormats = "csv.gz"',
                 '  physsim.linkStatsOutputFileType = "csv.gz"',
@@ -268,6 +271,7 @@ def test_build_beam_launch_config_applies_default_artifact_format_policy(
         )
 
     expected = {
+        "beam.router.skim.activity-sim-skimmer.fileBaseName": "skimsActivitySimOD",
         "beam.router.skim.activity-sim-skimmer.fileOutputFormat": "zarr",
         "beam.exchange.scenario.fileFormat": "parquet",
         "beam.outputs.events.fileOutputFormats": "parquet",

--- a/tests/test_beam_native_step_definitions.py
+++ b/tests/test_beam_native_step_definitions.py
@@ -644,6 +644,72 @@ def test_beam_postprocess_resolver_stages_dynamic_closure_at_exact_destinations(
     }
 
 
+def test_beam_postprocess_dynamic_keys_exclude_prior_iteration_zarr() -> None:
+    keys = (
+        "events_parquet_2018_1",
+        "raw_od_skims_zarr_2018_0",
+        "raw_od_skims_zarr_2018_1",
+    )
+
+    assert beam_steps._postprocess_dynamic_keys(
+        storage_keys=keys,
+        year=2018,
+        iteration=1,
+    ) == (
+        "events_parquet_2018_1",
+        "raw_od_skims_zarr_2018_1",
+    )
+
+
+def test_beam_postprocess_resolver_uses_completed_beam_outputs_over_coupler_history(
+    tmp_path: Path,
+) -> None:
+    events_path = tmp_path / "events.parquet"
+    _write_event_types(events_path, ["PathTraversal"])
+    prior_skims = tmp_path / "prior.zarr"
+    current_skims = tmp_path / "current.zarr"
+    prior_skims.mkdir()
+    current_skims.mkdir()
+
+    class Coupler:
+        def __init__(self) -> None:
+            self.values = {
+                "events_parquet_2018_0": tmp_path / "prior-events.parquet",
+                "raw_od_skims_zarr_2018_0": prior_skims,
+                ZARR_SKIMS: tmp_path / "asim-skims.zarr",
+            }
+
+        def get(self, key: str, default: object = None) -> object:
+            return self.values.get(key, default)
+
+        def keys(self):
+            return self.values.keys()
+
+    workspace = SimpleNamespace(
+        get_beam_mutable_data_dir=lambda: str(tmp_path / "beam-input"),
+        get_beam_output_dir=lambda: str(tmp_path / "beam-output"),
+        get_asim_output_dir=lambda: str(tmp_path / "asim-output"),
+    )
+    resolved = beam_steps._resolve_beam_postprocess_inputs(
+        settings=SimpleNamespace(activitysim=object()),
+        state=SimpleNamespace(year=2018, iteration=1),
+        workspace=workspace,
+        coupler=Coupler(),
+        beam_run_outputs={
+            "events_parquet_2018_1": events_path,
+            "raw_od_skims_zarr_2018_1": current_skims,
+        },
+    )
+
+    assert set(resolved.binding.inputs or {}) == {
+        "events_parquet_2018_1",
+        "raw_od_skims_zarr_2018_1",
+        ZARR_SKIMS,
+    }
+    assert resolved.source_by_role["events_parquet_2018_1"] == "explicit"
+    assert resolved.source_by_role["raw_od_skims_zarr_2018_1"] == "explicit"
+
+
 def test_beam_required_roles_do_not_resolve_from_a_namespace_view(
     tmp_path: Path,
 ) -> None:
@@ -1082,7 +1148,7 @@ def test_beam_run_declares_closed_individually_keyed_handoff_outputs(
     )
 
 
-def test_beam_postprocess_dynamic_closure_destinations_do_not_collide(
+def test_beam_postprocess_dynamic_closure_excludes_non_numeric_suffixes(
     tmp_path: Path,
 ) -> None:
     selected_events = tmp_path / "source-events_parquet_2030_2.parquet"
@@ -1115,7 +1181,6 @@ def test_beam_postprocess_dynamic_closure_destinations_do_not_collide(
 
     assert set(closure) == {
         "events_parquet_2030_2",
-        "events_parquet_2030_2_retry",
         "raw_od_skims_2030_2",
     }
     assert len(set(closure.values())) == len(closure)

--- a/tests/test_beam_runner_outputs.py
+++ b/tests/test_beam_runner_outputs.py
@@ -91,6 +91,24 @@ def test_gather_outputs_discovers_activitysim_omx_basename(tmp_path):
     assert by_name["raw_od_skims_2030_2"].file_path == str(skim_path)
 
 
+def test_gather_outputs_prefers_configured_activitysim_zarr_basename(tmp_path):
+    beam_output_dir = tmp_path / "beam-output"
+    iteration_dir = beam_output_dir / "seattle" / "run" / "ITERS" / "it.2"
+    legacy_path = iteration_dir / "2.skimsActivitySimOD_current.zarr"
+    configured_path = iteration_dir / "2.regionalActivitySimOD_current.zarr"
+    _touch(legacy_path)
+    _touch(configured_path)
+
+    runner = BeamRunner("beam_runner", _StubState())
+    outputs = runner.gather_outputs(
+        str(beam_output_dir),
+        activitysim_skims_file_base_name="regionalActivitySimOD",
+    )
+
+    by_name = {record.short_name: record for record in outputs}
+    assert by_name["raw_od_skims_zarr_2030_2"].file_path == str(configured_path)
+
+
 def test_beam_runner_run_returns_typed_outputs(tmp_path, monkeypatch) -> None:
     state = _StubState()
     runner = BeamRunner("beam_runner", state)
@@ -160,7 +178,11 @@ def test_beam_runner_mounts_the_bound_launch_tree(
     state.current_inner_iter = 2
     state.full_settings = SimpleNamespace(
         run=SimpleNamespace(region="seattle"),
-        beam=SimpleNamespace(config="beam.conf", memory="4g"),
+        beam=SimpleNamespace(
+            config="beam.conf",
+            memory="4g",
+            activitysim_skims_file_base_name="skimsActivitySimOD",
+        ),
         shared=SimpleNamespace(skims=SimpleNamespace(fname="skims.omx")),
     )
     runner = BeamRunner("beam_runner", state)


### PR DESCRIPTION
## Summary

Fix the ActivitySim/BEAM second-iteration failure caused by postprocessing selecting stale BEAM skim artifacts from Coupler history.

- Bind fresh `beam_postprocess` dynamic inputs directly to the completed `beam_run` outputs.
- Restrict dynamic artifact selection to the exact forecast year and iteration, including Zarr skims and numeric BEAM sub-iterations only.
- Add a typed PILATES-owned ActivitySim skim writer basename and materialize it into BEAM’s `fileBaseName`.
- Keep Zarr as the default ActivitySim skim output format.
- Prefer the configured skim basename during output discovery, while retaining legacy basename support for compatibility.

## Problem

The scenario Coupler can retain outputs from prior supply-demand iterations. When the current BEAM run emits Zarr OD skims but no OMX skims, the old dynamic-key fallback could include a prior iteration’s Zarr artifact. Checkpoint closure validation correctly rejected that stale artifact because it was not produced by the current BEAM run.

BEAM output discovery also supported multiple historical ActivitySim skim basenames, but PILATES did not own or materialize a deterministic writer basename.

## Implementation

- `beam_postprocess` now receives the current `run_result.outputs` explicitly for fresh successor resolution.
- Dynamic keys admit only:
  - `events_parquet_{year}_{iteration}`
  - `raw_od_skims_{year}_{iteration}`
  - `raw_od_skims_zarr_{year}_{iteration}`
  - numeric `_subN` variants
- Added `beam.activitysim_skims_file_base_name`, defaulting to `skimsActivitySimOD`.
- The derived BEAM launch config now sets:
  - `beam.router.skim.activity-sim-skimmer.fileBaseName`
  - `beam.router.skim.activity-sim-skimmer.fileOutputFormat`
- Source BEAM configurations must explicitly declare `fileBaseName`; the standard ActivitySim skimmer configuration already does.
